### PR TITLE
feat: sync mobile header color with canvas foreground

### DIFF
--- a/src/components/mobile.ts
+++ b/src/components/mobile.ts
@@ -725,8 +725,15 @@ export async function setupMobileLayout(
     'fixed inset-0 flex flex-col items-center justify-center bg-white dark:bg-gray-900 overflow-hidden'
 
   const { root: headerRoot, elements: headerElements } = createMobileHeader()
-  const cleanupHeader = setupMobileHeader(headerElements, headerRoot)
+  const { cleanup: cleanupHeader, resetFade: resetHeaderFade } =
+    setupMobileHeader(headerElements, headerRoot)
   container.appendChild(headerRoot)
+
+  // Helper function to update header title color and reset fade
+  const updateHeaderColor = (color: string) => {
+    headerElements.titleElement.style.color = color
+    resetHeaderFade()
+  }
 
   const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
   const palette = isDark ? DARK_FG_COLORS : LIGHT_FG_COLORS
@@ -839,6 +846,9 @@ export async function setupMobileLayout(
   offscreenReady = true
 
   initializeRunStats(onScreenCA, onScreenRule)
+
+  // Set initial header color to match canvas
+  updateHeaderColor(palette[colorIndex])
 
   // Create stats overlay
   const {
@@ -962,6 +972,9 @@ export async function setupMobileLayout(
       const nextCol = palette[(colorIndex + 1) % palette.length]
       onScreenCA.setColors(col, bgColor)
       offScreenCA.setColors(nextCol, bgColor)
+
+      // Update header color to match new canvas color
+      updateHeaderColor(col)
 
       // Defer CA operations by one frame to let layout settle
       setTimeout(() => {

--- a/src/components/mobileHeader.ts
+++ b/src/components/mobileHeader.ts
@@ -1,6 +1,7 @@
 // src/components/mobileHeader.ts
 
 export interface MobileHeaderElements {
+  titleElement: HTMLHeadingElement
   infoButton: HTMLButtonElement
   infoOverlay: HTMLDivElement
   closeButton: HTMLButtonElement
@@ -20,7 +21,7 @@ export function createMobileHeader(): {
   root.innerHTML = `
     <div class="px-6 py-3 flex items-center justify-between">
       <!-- Left: Logo/Title -->
-      <h1 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+      <h1 id="rulehunt-title" class="text-xl font-bold text-gray-900 dark:text-gray-100 transition-colors duration-500">
         RuleHunt
       </h1>
 
@@ -148,6 +149,7 @@ export function createMobileHeader(): {
   document.body.appendChild(infoOverlay)
 
   const elements: MobileHeaderElements = {
+    titleElement: root.querySelector('#rulehunt-title') as HTMLHeadingElement,
     infoButton: root.querySelector('#info-button') as HTMLButtonElement,
     infoOverlay: infoOverlay,
     closeButton: infoOverlay.querySelector('#close-info') as HTMLButtonElement,
@@ -159,7 +161,7 @@ export function createMobileHeader(): {
 export function setupMobileHeader(
   elements: MobileHeaderElements,
   headerRoot: HTMLElement,
-): CleanupFunction {
+): { cleanup: CleanupFunction; resetFade: () => void } {
   const { infoButton, infoOverlay, closeButton } = elements
 
   let fadeTimer: number | null = null
@@ -209,19 +211,22 @@ export function setupMobileHeader(
   // Start the initial fade timer
   resetFade()
 
-  // Return cleanup function
-  return () => {
-    if (fadeTimer) clearTimeout(fadeTimer)
-    infoButton.removeEventListener('click', infoHandler)
-    closeButton.removeEventListener('click', closeHandler)
-    infoOverlay.removeEventListener('click', overlayClickHandler)
+  // Return cleanup function and resetFade function
+  return {
+    cleanup: () => {
+      if (fadeTimer) clearTimeout(fadeTimer)
+      infoButton.removeEventListener('click', infoHandler)
+      closeButton.removeEventListener('click', closeHandler)
+      infoOverlay.removeEventListener('click', overlayClickHandler)
 
-    // Clean up overlay from DOM
-    if (infoOverlay.parentNode) {
-      infoOverlay.parentNode.removeChild(infoOverlay)
-    }
+      // Clean up overlay from DOM
+      if (infoOverlay.parentNode) {
+        infoOverlay.parentNode.removeChild(infoOverlay)
+      }
 
-    // Restore body scroll in case it was locked
-    document.body.style.overflow = ''
+      // Restore body scroll in case it was locked
+      document.body.style.overflow = ''
+    },
+    resetFade,
   }
 }


### PR DESCRIPTION
## Summary
Implements issue #16 - make the "RuleHunt" text in the mobile header dynamically match the foreground color of the on-screen canvas with smooth transitions.

## Changes

### Mobile Header Interface (`src/components/mobileHeader.ts`)
- Added `titleElement: HTMLHeadingElement` to `MobileHeaderElements` interface
- Added `transition-colors duration-500` class to h1 for smooth 500ms color transitions
- Modified `setupMobileHeader()` to return object with `cleanup` and `resetFade` functions
- Exposes `resetFade()` so header can return to full opacity when color changes

### Mobile Integration (`src/components/mobile.ts`)
- Created `updateHeaderColor(color: string)` helper function
- Sets `titleElement.style.color` to match canvas foreground
- Calls `resetHeaderFade()` to restore header to full visibility
- Invoked after initial CA setup (line 844)
- Invoked in swipe onCommit callback after color update (line 967)

## Behavior

1. **Dynamic Color Matching**: Header title color tracks canvas foreground color palette
2. **Smooth Transitions**: CSS transition provides 500ms ease between colors
3. **Fade Reset**: Header returns to full opacity (1.0) when user swipes to new pattern
4. **Auto-Fade**: After 3 seconds, fades to 30% opacity (inherited from PR#14)

## Stacking

This PR is stacked on top of:
- **PR#14** (`feat/fade-mobile-header`) - Adds auto-fade behavior to mobile header

Base branch: `feat/fade-mobile-header`
Target for merge: This PR should merge into `feat/fade-mobile-header`, then both can merge to `main`

## Testing

- ✅ TypeScript compilation passes
- ✅ Linter passes  
- ✅ Build succeeds
- [ ] Manual testing: Header color matches canvas color on mobile
- [ ] Manual testing: Header becomes fully visible when swiping
- [ ] Manual testing: Smooth 500ms color transitions work correctly
- [ ] Manual testing: Combined with PR#14, header fades then restores on color change

Resolves #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)