### PR TITLE
docs: add Claude Code PR review documentation and slash commands

### DIFF
--- a/.claude/commands/review-api.md
+++ b/.claude/commands/review-api.md
@@ -1,0 +1,13 @@
+Review API endpoint PR #$ARGUMENTS:
+
+1. Fetch PR: `gh pr view $ARGUMENTS`
+2. Get diff: `gh pr diff $ARGUMENTS`
+3. Check for:
+   - Zod schema validation on all inputs
+   - Proper error handling (try/catch with appropriate status codes)
+   - SQL injection prevention (use parameterized queries only)
+   - Consistent error response format: `{ ok: false, error: string }`
+   - TypeScript types match Zod schemas
+4. Post review: `gh pr review $ARGUMENTS --comment --body "<findings>"`
+
+Focus on API security and consistency with existing endpoints.

--- a/.claude/commands/review-migration.md
+++ b/.claude/commands/review-migration.md
@@ -1,0 +1,13 @@
+Review database migration PR #$ARGUMENTS:
+
+1. Fetch PR: `gh pr view $ARGUMENTS`
+2. Get diff: `gh pr diff $ARGUMENTS`
+3. Check for:
+   - SQL syntax errors (SQLite dialect)
+   - Appropriate indexes (partial indexes for boolean filters)
+   - Column types match schema.ts Zod definitions
+   - Migration naming: `NNNN_description.sql` pattern
+   - Reversibility (if applicable)
+4. Post review: `gh pr review $ARGUMENTS --comment --body "<findings>"`
+
+Focus on database schema correctness and performance.

--- a/.claude/commands/review-ui.md
+++ b/.claude/commands/review-ui.md
@@ -1,0 +1,14 @@
+Review UI component PR #$ARGUMENTS:
+
+1. Fetch PR: `gh pr view $ARGUMENTS`
+2. Get diff: `gh pr diff $ARGUMENTS`
+3. Check for:
+   - Swipe gesture conflicts (uses data-swipe-ignore where needed)
+   - Event swallowing pattern for touch events (passive: true)
+   - Cleanup function returned and all listeners removed
+   - Accessibility (ARIA labels, semantic HTML)
+   - Theme support (dark/light mode CSS classes)
+   - Mobile-first responsive design
+4. Post review: `gh pr review $ARGUMENTS --comment --body "<findings>"`
+
+Focus on mobile UX and the dual-canvas swipe system integrity.

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ tsconfig.tsbuildinfo
 /.direnv
 /result
 
-.claude/
+.claude/*
+!.claude/commands/
 
 # Cloudflare Wrangler local state (D1, KV, R2, etc.)
 .wrangler/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,81 @@ Distributed exploration of 2^140 C4-symmetric cellular automata rules. TikTok-st
 - `pnpm run build` - Full production build (tsc + vite + copy resources)
 - `pnpm run dev` - Local Vite dev server
 
+## PR Reviews with Claude Code
+
+RuleHunt uses custom slash commands to streamline PR reviews with
+component-specific criteria. Reviews leverage Claude Code's GitHub CLI
+integration (`gh pr view`, `gh pr diff`, `gh pr review`).
+
+### Quick Review Pattern
+
+For general reviews, use natural language:
+```bash
+claude
+Please review PR #42 and post your findings
+```
+
+For component-specific reviews, use slash commands:
+```bash
+claude
+/review-migration 21  # Database schema changes
+/review-api 23        # API endpoint changes
+/review-ui 24         # UI component changes
+```
+
+### Slash Command Usage
+
+**Database migrations:**
+```bash
+/review-migration <PR_NUMBER>
+```
+
+**API endpoints:**
+```bash
+/review-api <PR_NUMBER>
+```
+
+**UI components:**
+```bash
+/review-ui <PR_NUMBER>
+```
+
+### Review Criteria by Component
+
+| Component | Key Checks |
+|-----------|------------|
+| **Database Migrations** | SQLite syntax, indexes (partial for booleans), schema.ts alignment, naming (`NNNN_description.sql`) |
+| **API Endpoints** | Zod validation, parameterized queries, error format `{ ok: false, error: string }`, status codes |
+| **UI Components** | No swipe conflicts (`data-swipe-ignore`), event cleanup, theme support, touch optimization (`passive: true`) |
+| **CA Engine** | Interface stability, explicit operations, memory cleanup (`destroy()`), GPU fallback |
+| **Utils/Core** | Pure functions, explicit return types, unit tests, no `any` types |
+
+### Examples
+
+**Review a migration PR:**
+```bash
+claude
+/review-migration 21
+```
+Claude will fetch the diff, check SQL syntax, verify indexes, compare with
+schema.ts, and post findings directly to the PR.
+
+**Review an API PR:**
+```bash
+claude
+/review-api 23
+```
+Claude will verify Zod validation, check for SQL injection prevention, test
+error handling patterns, and ensure consistency with existing endpoints.
+
+**Review a UI PR:**
+```bash
+claude
+/review-ui 24
+```
+Claude will check for swipe gesture conflicts, verify event cleanup, test
+theme support, and validate mobile-first responsive patterns.
+
 ## Architecture
 
 **Entry Point:** `src/main.ts` - Detects mobile/desktop (<640px breakpoint), mounts layout


### PR DESCRIPTION
## Summary
Add documentation and custom slash commands to enable consistent PR reviews using Claude Code with GitHub CLI integration.

Resolves #23

## Changes

### 1. Documentation: CLAUDE.md

Added new section **"PR Reviews with Claude Code"** after the "Commands" section.

**Includes:**
- Quick review pattern using natural language
- Instructions for using custom slash commands
- Component-specific review criteria table
- Usage examples for each review type

**Review Criteria Table:**

| Component | Key Checks |
|-----------|------------|
| **Database Migrations** | SQLite syntax, indexes (partial for booleans), schema.ts alignment, naming (`NNNN_description.sql`) |
| **API Endpoints** | Zod validation, parameterized queries, error format `{ ok: false, error: string }`, status codes |
| **UI Components** | No swipe conflicts (`data-swipe-ignore`), event cleanup, theme support, touch optimization (`passive: true`) |
| **CA Engine** | Interface stability, explicit operations, memory cleanup (`destroy()`), GPU fallback |
| **Utils/Core** | Pure functions, explicit return types, unit tests, no `any` types |

### 2. Slash Commands

Created three specialized review commands in `.claude/commands/`:

**`review-migration.md`** - Database schema reviews
- Checks SQL syntax (SQLite dialect)
- Verifies indexes (partial indexes for boolean filters)
- Validates schema.ts alignment
- Confirms migration naming: `NNNN_description.sql`
- Assesses reversibility

**`review-api.md`** - API endpoint reviews
- Validates Zod schema on all inputs
- Checks error handling (try/catch with status codes)
- Prevents SQL injection (parameterized queries only)
- Ensures error format: `{ ok: false, error: string }`
- Verifies TypeScript/Zod type alignment

**`review-ui.md`** - UI component reviews
- Checks swipe gesture conflicts (`data-swipe-ignore`)
- Validates event swallowing pattern (`passive: true`)
- Verifies cleanup functions and listener removal
- Tests accessibility (ARIA labels, semantic HTML)
- Confirms theme support (dark/light CSS classes)
- Validates mobile-first responsive design

### 3. Gitignore Update

Modified `.gitignore` to:
- Keep `.claude/*` ignored (user-specific settings)
- Allow `.claude/commands/` to be committed (shared commands)

```diff
-.claude/
+.claude/*
+!.claude/commands/
```

## Usage

### Natural Language Review
```bash
claude
Please review PR #42 and post your findings
```

### Component-Specific Reviews
```bash
claude
/review-migration 21  # Database schema changes
/review-api 23        # API endpoint changes
/review-ui 24         # UI component changes
```

## Command Flow

Each slash command follows this pattern:
1. **Fetch PR**: `gh pr view $ARGUMENTS`
2. **Get diff**: `gh pr diff $ARGUMENTS`
3. **Perform checks**: Component-specific validation
4. **Post review**: `gh pr review $ARGUMENTS --comment --body "<findings>"`

## Benefits

✅ **Consistency**: Standardized review criteria across all PRs
✅ **Efficiency**: Automated fetching and posting with gh CLI
✅ **Context-aware**: Checks aligned with codebase patterns
✅ **Self-documenting**: Criteria visible in CLAUDE.md
✅ **Reusable**: Commands work for all PRs of that type

## File Structure After Implementation

```
.claude/
└── commands/
    ├── review-migration.md
    ├── review-api.md
    └── review-ui.md
CLAUDE.md (updated)
.gitignore (updated)
```

## Testing

Verified:
- ✅ CLAUDE.md section placed after "Commands", before "Architecture"
- ✅ Three slash command files created with proper structure
- ✅ Commands use `$ARGUMENTS` placeholder correctly
- ✅ All commands use `gh pr view`, `gh pr diff`, `gh pr review`
- ✅ Review criteria align with existing codebase patterns
- ✅ Documentation includes usage examples
- ✅ Files follow project markdown formatting

## Next Steps

Contributors can now use:
```bash
claude
/review-migration 1
/review-api 2
/review-ui 3
```

To perform consistent, thorough PR reviews aligned with RuleHunt's code patterns and conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)