### PR TITLE
feat: sync URL with simulation state changes

### DIFF
--- a/src/components/desktop.ts
+++ b/src/components/desktop.ts
@@ -13,7 +13,11 @@ import {
   randomC4RulesetByDensity,
 } from '../utils.ts'
 
-import { parseURLRuleset, parseURLState } from '../urlState.ts'
+import {
+  parseURLRuleset,
+  parseURLState,
+  updateURLWithoutReload,
+} from '../urlState.ts'
 import { setupBenchmarkModal } from './benchmark.ts'
 import { createHeader, setupTheme } from './desktopHeader.ts'
 import { createLeaderboardPanel } from './leaderboard.ts'
@@ -420,6 +424,7 @@ export async function setupDesktopLayout(
       progressBar,
     )
     initializeSimulationMetadata()
+    updateURL()
   }
 
   function initializeSimulationMetadata() {
@@ -441,6 +446,23 @@ export async function setupDesktopLayout(
       requestedStepsPerSecond: cellularAutomata.isCurrentlyPlaying()
         ? stepsPerSecond
         : undefined,
+    })
+  }
+
+  function updateURL() {
+    const rulesetHex = c4RulesetToHex(currentRuleset)
+    const seed = cellularAutomata.getSeed()
+
+    let seedPercentage: number | undefined
+    if (initialConditionType === 'random' || initialConditionType === 'patch') {
+      seedPercentage = Number.parseInt(aliveSlider.value)
+    }
+
+    updateURLWithoutReload({
+      rulesetHex,
+      seed,
+      seedType: initialConditionType,
+      seedPercentage,
     })
   }
 
@@ -469,6 +491,7 @@ export async function setupDesktopLayout(
       const expanded = expandC4Ruleset(currentRuleset, orbitLookup)
       cellularAutomata.play(stepsPerSecond, expanded)
     }
+    // URL already updated by applyInitialCondition()
   }
 
   // Initialize with URL ruleset if available, otherwise Conway
@@ -704,6 +727,7 @@ export async function setupDesktopLayout(
         progressBar,
       )
       initializeSimulationMetadata()
+      updateURL()
     } else {
       applyInitialCondition()
     }

--- a/src/components/mobile.ts
+++ b/src/components/mobile.ts
@@ -24,7 +24,11 @@ import {
 } from '../utils.ts'
 import { createStatsOverlay, setupStatsOverlay } from './statsOverlay.ts'
 
-import { parseURLRuleset, parseURLState } from '../urlState.ts'
+import {
+  parseURLRuleset,
+  parseURLState,
+  updateURLWithoutReload,
+} from '../urlState.ts'
 import { createMobileHeader, setupMobileHeader } from './mobileHeader.ts'
 
 // --- Constants --------------------------------------------------------------
@@ -1034,6 +1038,14 @@ export async function setupMobileLayout(
         offScreenRule = generateRandomRule()
         prepareAutomata(offScreenCA, offScreenRule, lookup, 50)
         offscreenReady = true
+
+        // Update URL to match current simulation state
+        updateURLWithoutReload({
+          rulesetHex: onScreenRule.hex,
+          seed: onScreenCA.getSeed(),
+          seedType: 'patch',
+          seedPercentage: 50,
+        })
       }, 16)
 
       softResetButton.remove()


### PR DESCRIPTION
## Summary
Implements issue #34 - URL automatically updates to match current simulation state, allowing users to copy and share directly from the browser address bar.

## Changes

**Desktop URL Updates** (`src/components/desktop.ts`)
- Added `updateURL()` helper function that captures current state (rulesetHex, seed, seedType, seedPercentage)
- URL updates when initial condition is applied
- URL updates when reset button is clicked (seed advances in soft reset)
- Works with all three IC modes: center, random, and patch

**Mobile URL Updates** (`src/components/mobile.ts`)
- URL updates in swipe `onCommit` callback after transitioning to new pattern
- Captures new on-screen ruleset hex and seed
- Uses patch/50% (mobile's default IC settings)

## Behavior

**Desktop:**
- URL stays in sync with current ruleset, seed, IC type, and alive percentage
- Updates occur when:
  - Initial condition type changes (center/random/patch radio buttons)
  - Alive percentage slider changes and IC is reapplied
  - Reset button is clicked (advances seed in soft reset)
  - New random rule is generated

**Mobile:**
- URL updates after each swipe to new pattern
- Reflects current visible CA ruleset and seed
- User can copy URL from address bar to share exact state

## Benefits

- **Seamless sharing**: Users can copy URL directly from browser without clicking share button
- **State persistence**: Browser back/forward buttons work with simulation states
- **Complements PR #32**: Share button and URL bar both provide shareable links
- **Builds on PR #17**: Uses existing `updateURLWithoutReload()` infrastructure

## Testing

- ✅ TypeScript compilation passes
- ✅ Biome linter passes  
- ✅ All 51 tests pass
- [ ] Manual testing: Desktop URL updates on IC changes
- [ ] Manual testing: Desktop URL updates on reset
- [ ] Manual testing: Mobile URL updates on swipe

Resolves #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)