### PR TITLE
fix: only apply URL seed on initial load, not every swipe

### DIFF
--- a/src/components/mobile.ts
+++ b/src/components/mobile.ts
@@ -859,38 +859,16 @@ export async function setupMobileLayout(
 
   let offScreenRule = generateRandomRule()
 
-  // Apply URL seed and initial condition if provided
+  // Apply URL seed if provided (only on initial load)
   if (urlState.seed !== undefined) {
     onScreenCA.setSeed(urlState.seed)
-    offScreenCA.setSeed(urlState.seed + 1) // Different seed for offscreen
     console.log('[mobile] Using seed from URL:', urlState.seed)
   }
 
-  // Apply initial condition based on URL parameters (if provided)
-  if (urlState.seedType || urlState.seedPercentage !== undefined) {
-    const seedType = urlState.seedType || 'patch' // Default to patch
-    const seedPercentage = urlState.seedPercentage ?? 50 // Default to 50%
-
-    switch (seedType) {
-      case 'center':
-        onScreenCA.centerSeed()
-        break
-      case 'random':
-        onScreenCA.randomSeed(seedPercentage)
-        break
-      default:
-        onScreenCA.patchSeed()
-        break
-    }
-    console.log(
-      '[mobile] Applied seed type from URL:',
-      seedType,
-      seedPercentage,
-    )
-  }
-
   // Initial setup with explicit renders
-  prepareAutomata(onScreenCA, onScreenRule, lookup)
+  // Use URL seedPercentage if provided, otherwise default to 50%
+  const initialSeedPercentage = urlState.seedPercentage ?? 50
+  prepareAutomata(onScreenCA, onScreenRule, lookup, initialSeedPercentage)
   startAutomata(onScreenCA, onScreenRule)
 
   prepareAutomata(offScreenCA, offScreenRule, lookup)


### PR DESCRIPTION
## Problem

PR #35 introduced a bug where URL seed parameters were not being applied correctly on mobile. The code would:

1. Parse URL seed and seedType on initial load
2. Call `setSeed()` and then `centerSeed()`/`randomSeed()`/`patchSeed()` based on URL
3. Immediately call `prepareAutomata()` which calls `patchSeed()` **again**, overwriting the URL initial condition

This caused the URL initial condition to be applied and then immediately overwritten, and seeds wouldn't advance properly on swipes.

## Solution

Simplified URL parameter handling:
- **Only set the seed** from URL on initial load using `setSeed()`  
- **Let `prepareAutomata()` handle IC setup** (it already calls `patchSeed()`)
- **Pass URL seedPercentage** to `prepareAutomata()` if provided
- **Removed redundant IC code** (centerSeed/randomSeed/patchSeed switch)

## Behavior After Fix

- **Initial load with URL**: Uses URL seed and seedPercentage correctly
- **Every swipe**: Generates completely new random rule with new seed
- **Seed advances naturally**: CA's internal RNG advances through normal operation

## Changes

**src/components/mobile.ts:862-876**
- Removed URL seedType conditional application  
- Removed duplicate calls to centerSeed/randomSeed/patchSeed
- Only call `setSeed()` if URL provides a seed
- Pass `urlState.seedPercentage ?? 50` to `prepareAutomata()`

## Testing

- ✅ TypeScript compilation passes
- ✅ Linter passes  
- ✅ All tests pass
- [ ] Manual test: Swipe generates new random rules
- [ ] Manual test: URL with seed loads correctly
- [ ] Manual test: Seed advances on each swipe

## Impact

Fixes critical bug introduced in PR #35 where mobile would not generate new random rules on swipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)