### PR TITLE
fix: update GitHub links to new repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Pattern scores are stored in the database automatically.
 
 ```bash
 # Clone the repository
-git clone https://github.com/irgolic/rulehunt.git
+git clone https://github.com/rulehunt/rulehunt.git
 cd rulehunt
 
 # Install dependencies (if using a build system)

--- a/src/components/desktopHeader.ts
+++ b/src/components/desktopHeader.ts
@@ -37,9 +37,9 @@ export function createHeader(): {
       <!-- Right: GitHub + Theme Toggle -->
       <div class="flex items-center gap-4">
         <!-- GitHub Link -->
-        <a 
+        <a
           id="github-link"
-          href="https://github.com/irgolic/rulehunt/tree/main" 
+          href="https://github.com/rulehunt/rulehunt"
           target="_blank"
           rel="noopener noreferrer"
           class="flex items-center gap-2 px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-sm"

--- a/src/components/mobileHeader.ts
+++ b/src/components/mobileHeader.ts
@@ -131,8 +131,8 @@ export function createMobileHeader(): {
 
       <!-- Footer -->
       <div class="sticky bottom-0 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-6 py-4">
-        <a 
-          href="https://github.com/irgolic/rulehunt" 
+        <a
+          href="https://github.com/rulehunt/rulehunt"
           target="_blank"
           rel="noopener noreferrer"
           class="flex items-center justify-center gap-2 w-full px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"


### PR DESCRIPTION
## Summary

Updates all GitHub links from  to  after the repository was moved to the rulehunt organization.

Resolves #44

## Changes

### Desktop Header ()
- Updated GitHub link from 
- To: 

### Mobile Header ()
- Updated GitHub link in info overlay footer
- From: 
- To: 

### README ()
- Updated git clone command
- From: 
- To: 

## Testing

- ✅ TypeScript compilation passes
- ✅ Linter passes
- ✅ Build succeeds
- ✅ Links point to correct repository

All GitHub links now correctly point to the new  organization repository.