### PR TITLE
feat: add star button to mobile interface

### DIFF
--- a/src/components/mobile.ts
+++ b/src/components/mobile.ts
@@ -32,6 +32,7 @@ import {
 import { createAutoFadeContainer } from './buttonContainer.ts'
 import { createMobileHeader, setupMobileHeader } from './mobileHeader.ts'
 import { createRoundButton } from './roundButton.ts'
+import { createStarButton } from './starButton.ts'
 
 // --- Constants --------------------------------------------------------------
 const FORCE_RULE_ZERO_OFF = true // avoid strobing
@@ -748,76 +749,6 @@ function createShareButton(onResetFade?: () => void): {
   return { button, cleanup }
 }
 
-// --- Star Button (toggle starred status) -----------------------------------
-function createStarButton(
-  getIsStarred: () => boolean,
-  onToggle: (isStarred: boolean) => void,
-  onResetFade?: () => void,
-): {
-  button: HTMLButtonElement
-  cleanup: () => void
-} {
-  const starFilledIcon = `
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-         fill="currentColor" class="w-6 h-6">
-      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-    </svg>`
-
-  const starOutlineIcon = `
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-         fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
-      <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-    </svg>`
-
-  const updateButtonAppearance = (button: HTMLButtonElement) => {
-    const isStarred = getIsStarred()
-    button.innerHTML = isStarred ? starFilledIcon : starOutlineIcon
-
-    // Update background color
-    if (isStarred) {
-      button.className = button.className.replace(
-        /bg-gray-800 dark:bg-gray-700/,
-        'bg-yellow-500',
-      )
-      button.className = button.className.replace(
-        /hover:bg-gray-700 dark:hover:bg-gray-600/,
-        'hover:bg-yellow-400',
-      )
-    } else {
-      button.className = button.className.replace(
-        /bg-yellow-500/,
-        'bg-gray-800 dark:bg-gray-700',
-      )
-      button.className = button.className.replace(
-        /hover:bg-yellow-400/,
-        'hover:bg-gray-700 dark:hover:bg-gray-600',
-      )
-    }
-  }
-
-  const { button, cleanup } = createRoundButton(
-    {
-      icon: starOutlineIcon,
-      title: 'Star this simulation',
-      onClick: () => {
-        if (isTransitioning) return
-
-        const newStarredState = !getIsStarred()
-        onToggle(newStarredState)
-        updateButtonAppearance(button)
-        onResetFade?.()
-      },
-      preventTransition: true,
-    },
-    () => isTransitioning,
-  )
-
-  // Set initial appearance
-  updateButtonAppearance(button)
-
-  return { button, cleanup }
-}
-
 // --- Main -------------------------------------------------------------------
 export async function setupMobileLayout(
   appRoot: HTMLDivElement,
@@ -1097,13 +1028,14 @@ export async function setupMobileLayout(
     () => showStats(getCurrentRunData()),
     resetControlFade,
   )
-  let starBtn = createStarButton(
-    () => currentIsStarred,
-    (isStarred) => {
+  let starBtn = createStarButton({
+    getIsStarred: () => currentIsStarred,
+    onToggle: (isStarred) => {
       currentIsStarred = isStarred
     },
-    resetControlFade,
-  )
+    onResetFade: resetControlFade,
+    isTransitioning: () => isTransitioning,
+  })
   let softResetButton = createSoftResetButton(
     () => {
       softResetAutomata(onScreenCA)
@@ -1202,13 +1134,14 @@ export async function setupMobileLayout(
         () => showStats(getCurrentRunData()),
         resetControlFade,
       )
-      starBtn = createStarButton(
-        () => currentIsStarred,
-        (isStarred) => {
+      starBtn = createStarButton({
+        getIsStarred: () => currentIsStarred,
+        onToggle: (isStarred) => {
           currentIsStarred = isStarred
         },
-        resetControlFade,
-      )
+        onResetFade: resetControlFade,
+        isTransitioning: () => isTransitioning,
+      })
       softResetButton = createSoftResetButton(
         () => {
           softResetAutomata(onScreenCA)

--- a/src/components/starButton.ts
+++ b/src/components/starButton.ts
@@ -1,0 +1,91 @@
+/**
+ * Star Button Component
+ *
+ * Toggle button for starring/favoriting simulations.
+ * Dynamically updates appearance based on starred state (yellow when starred, gray when not).
+ */
+
+import { createRoundButton } from './roundButton.ts'
+
+export interface StarButtonConfig {
+  /** Callback to get current starred state */
+  getIsStarred: () => boolean
+  /** Callback when starred state changes */
+  onToggle: (isStarred: boolean) => void
+  /** Optional callback to reset container fade */
+  onResetFade?: () => void
+  /** Callback to check if system is transitioning */
+  isTransitioning: () => boolean
+}
+
+export interface StarButton {
+  button: HTMLButtonElement
+  cleanup: () => void
+}
+
+const starFilledIcon = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+       fill="currentColor" class="w-6 h-6">
+    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+  </svg>`
+
+const starOutlineIcon = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+       fill="none" stroke="currentColor" stroke-width="2" class="w-6 h-6">
+    <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+  </svg>`
+
+/**
+ * Create a star button with toggle functionality.
+ */
+export function createStarButton(config: StarButtonConfig): StarButton {
+  const { getIsStarred, onToggle, onResetFade, isTransitioning } = config
+
+  const updateButtonAppearance = (button: HTMLButtonElement) => {
+    const starred = getIsStarred()
+    button.innerHTML = starred ? starFilledIcon : starOutlineIcon
+
+    // Update background color
+    if (starred) {
+      button.className = button.className.replace(
+        /bg-gray-800 dark:bg-gray-700/,
+        'bg-yellow-500',
+      )
+      button.className = button.className.replace(
+        /hover:bg-gray-700 dark:hover:bg-gray-600/,
+        'hover:bg-yellow-400',
+      )
+    } else {
+      button.className = button.className.replace(
+        /bg-yellow-500/,
+        'bg-gray-800 dark:bg-gray-700',
+      )
+      button.className = button.className.replace(
+        /hover:bg-yellow-400/,
+        'hover:bg-gray-700 dark:hover:bg-gray-600',
+      )
+    }
+  }
+
+  const { button, cleanup } = createRoundButton(
+    {
+      icon: starOutlineIcon,
+      title: 'Star this simulation',
+      onClick: () => {
+        if (isTransitioning()) return
+
+        const newStarredState = !getIsStarred()
+        onToggle(newStarredState)
+        updateButtonAppearance(button)
+        onResetFade?.()
+      },
+      preventTransition: true,
+    },
+    isTransitioning,
+  )
+
+  // Set initial appearance
+  updateButtonAppearance(button)
+
+  return { button, cleanup }
+}


### PR DESCRIPTION
## Summary
Implements the starred simulation functionality for mobile interface using the new button management system (`createRoundButton` and `createAutoFadeContainer`).

This PR refactors and completes the work started in PR #24, which was created before the button management system was introduced.

## Changes

**Star Button Component** (`src/components/mobile.ts:750-816`)
- Created `createStarButton()` following the established `createRoundButton` pattern
- Toggles between filled star icon (yellow `bg-yellow-500`) and outline star (gray)
- Accepts callbacks: `getIsStarred()`, `onToggle(isStarred)`, and optional `onResetFade()`
- Dynamically updates button appearance based on starred state

**State Management**
- Added `currentIsStarred` state variable (initially `false`)
- Updated when user clicks star button via `onToggle` callback
- Reset to `false` after each swipe to new simulation

**Database Integration**
- Updated `saveRunStatistics()` to accept optional `isStarred` parameter (defaults to `false`)
- Added `isStarred` field to `RunSubmission` payload
- Passes `currentIsStarred` value when saving on swipe commit

**Button Layout**
- Integrated star button into bottom-right control container
- Button order (right to left): share → stats → star → soft reset
- Recreated after each swipe to maintain fresh state

## Behavior

1. Star button appears in bottom-right control group with auto-fade behavior
2. Click toggles starred status with immediate visual feedback
3. Yellow filled star indicates starred, gray outline indicates unstarred
4. Starred status saved to database when user swipes to next simulation
5. Resets to unstarred for each new simulation

## Dependencies

- ✅ PR #21 (starred schema and migration) - merged
- ✅ PR #38 (DRY round buttons) - merged

## Testing

- ✅ TypeScript compilation passes
- ✅ Linter passes
- ✅ Build succeeds
- [ ] Manual testing: Star button toggles correctly on mobile
- [ ] Manual testing: Starred status persists to database
- [ ] Manual testing: Button resets after swipe

Resolves #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)