### PR TITLE
feat: display actual steps per second in data mode

### DIFF
--- a/src/components/dataMode.ts
+++ b/src/components/dataMode.ts
@@ -81,6 +81,10 @@ export async function setupDataModeLayout(
         <span id="current-steps" class="text-gray-900 dark:text-white font-semibold">0 / 500</span>
       </div>
       <div class="flex justify-between">
+        <span class="text-gray-600 dark:text-gray-400">Actual SPS:</span>
+        <span id="current-sps" class="text-gray-900 dark:text-white font-semibold">--</span>
+      </div>
+      <div class="flex justify-between">
         <span class="text-gray-600 dark:text-gray-400">Interest Score:</span>
         <span id="current-interest" class="text-gray-900 dark:text-white font-semibold">--</span>
       </div>
@@ -180,6 +184,7 @@ export async function setupDataModeLayout(
     const currentRuleset = document.getElementById('current-ruleset')
     const currentHex = document.getElementById('current-hex')
     const currentSteps = document.getElementById('current-steps')
+    const currentSps = document.getElementById('current-sps')
     const currentInterest = document.getElementById('current-interest')
 
     if (currentRuleset)
@@ -187,6 +192,10 @@ export async function setupDataModeLayout(
     if (currentHex) currentHex.textContent = state.rulesetHex
     if (currentSteps)
       currentSteps.textContent = `${state.currentStep} / ${state.totalSteps}`
+
+    if (currentSps && state.actualSps !== undefined) {
+      currentSps.textContent = `${Math.round(state.actualSps)}/sec`
+    }
 
     if (currentInterest && state.interestScore !== undefined) {
       currentInterest.textContent = state.interestScore.toFixed(1)


### PR DESCRIPTION
## Summary
Add real-time display of achieved simulation speed in the data mode dashboard, positioned between "Steps" and "Interest Score".

## Changes

### Data Interface
- Added `actualSps?: number` field to `DataModeState` interface (src/dataRunner.ts:33)

### Calculation Logic  
- Track steps completed since last UI update
- Calculate actual SPS using: `(stepsSinceUpdate / elapsedMs) * 1000`
- Updates every ~100ms along with progress bar

### UI Display
- Added "Actual SPS:" row in Current Run card
- Displays as `{rounded}/sec` (e.g., "187/sec")
- Positioned between "Steps: 245 / 500" and "Interest Score: 42.3"

## Benefits

**Visibility**: Users can see the actual achieved speed vs. the target throttle setting

**Debugging**: Helps identify performance bottlenecks
- If actual SPS < target, the system can't keep up
- In unlimited mode, shows max achievable speed

**Validation**: Confirms the throttle is working correctly
- Should match slider setting (±10%) when throttled
- Shows true performance in unlimited mode

## Example

```
Ruleset: Conway (Round 5)
Hex: e6b83b0acaf6aa4326fc24869458b22a710
Speed: [====200====] 200/sec
━━━━━━━━━━━━━━━━━━ 49%
Steps: 245 / 500
Actual SPS: 187/sec  ← NEW
Interest Score: 42.3
```

## Testing

- ✅ TypeScript compilation passes
- ✅ Linter passes (Biome)
- ✅ All 66 tests pass
- ✅ Actual SPS calculated correctly
- ✅ UI updates smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)