### PR TITLE
fix: desktop soft reset now preserves play state

### DIFF
--- a/src/components/desktop.ts
+++ b/src/components/desktop.ts
@@ -758,6 +758,7 @@ export async function setupDesktopLayout(
     // Soft reset for patch and random modes (advances seed for new random ICs)
     // Center mode keeps existing behavior (deterministic single pixel)
     if (initialConditionType === 'patch' || initialConditionType === 'random') {
+      const wasPlaying = cellularAutomata.isCurrentlyPlaying()
       cellularAutomata.pause()
       cellularAutomata.clearGrid()
       cellularAutomata.softReset()
@@ -769,6 +770,13 @@ export async function setupDesktopLayout(
       )
       initializeSimulationMetadata()
       updateURL()
+
+      // Resume playing if it was playing before reset
+      if (wasPlaying) {
+        const stepsPerSecond = Number.parseInt(stepsPerSecondInput.value)
+        const expanded = expandC4Ruleset(currentRuleset, orbitLookup)
+        cellularAutomata.play(stepsPerSecond, expanded)
+      }
     } else {
       applyInitialCondition()
     }


### PR DESCRIPTION
## Summary
Fix bug where the soft reset button on desktop leaves the simulation in a paused state.

## Root Cause
The reset button handler was calling `cellularAutomata.pause()` but never resuming playback, even if the simulation was playing before the reset.

## Changes
- Capture `wasPlaying` state before pausing
- After soft reset completes (new seed, cleared grid, re-rendered), check if it was playing
- If it was playing, resume with the current steps-per-second setting

## Behavior

**Before:**
- Click reset while simulation is playing → simulation pauses and stays paused ❌

**After:**
- Click reset while simulation is playing → simulation resets and continues playing ✅
- Click reset while simulation is paused → simulation resets and stays paused ✅

## Code Pattern
This matches the behavior of other rule-changing buttons (Conway, Outlier, Random) which all check `isCurrentlyPlaying()` and resume if needed.

## Testing
- ✅ TypeScript compilation passes
- ✅ Linter passes
- [ ] Manual testing: Reset button preserves play state

🤖 Generated with [Claude Code](https://claude.com/claude-code)