### PR TITLE
style: use node: protocol for built-in module imports

### DIFF
--- a/scripts/generate-build-info.cjs
+++ b/scripts/generate-build-info.cjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
 // Generate build info for embedding in the application
-const { execSync } = require('child_process')
-const fs = require('fs')
-const path = require('path')
+const { execSync } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
 
 try {
   // Get git commit hash (short version)


### PR DESCRIPTION
## Summary
Update require() statements in `generate-build-info.cjs` to use the `node:` protocol prefix for built-in Node.js modules, resolving Biome linter warnings.

## Changes
- `require('child_process')` → `require('node:child_process')`
- `require('fs')` → `require('node:fs')`
- `require('path')` → `require('node:path')`

## Benefits
- **Explicit**: Makes it clear these are Node.js core modules, not third-party packages
- **Modern style**: Follows Node.js best practices for module imports
- **Clean linting**: Resolves all Biome linter warnings in this file

## Test plan
- [x] Linter passes without warnings
- [x] Build script functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)