### PR TITLE
chore: setup Claude Code workspace settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,46 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm run check)",
+      "Bash(pnpm run lint)",
+      "Bash(pnpm run lint:fix)",
+      "Bash(pnpm run build:*)",
+      "Bash(pnpm run dev)",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(npm install:*)",
+      "Bash(pnpm install:*)",
+      "Bash(pnpm add:*)",
+      "Read(./src/**)",
+      "Read(./functions/**)",
+      "Read(./scripts/**)",
+      "Read(./resources/**)",
+      "Read(./CLAUDE.md)",
+      "Read(./README.md)",
+      "Read(./package.json)",
+      "Read(./tsconfig.json)",
+      "Read(./vite.config.ts)",
+      "Read(./biome.json)",
+      "Edit(./src/**)",
+      "Edit(./functions/**)",
+      "Edit(./scripts/**)",
+      "Write(./src/**)",
+      "Write(./functions/**)",
+      "Write(./scripts/**)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Edit(./.env)",
+      "Edit(./.env.*)",
+      "Write(./.env)",
+      "Write(./.env.*)",
+      "Bash(rm *)",
+      "Bash(rm:*)",
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Bash(npm publish:*)",
+      "Bash(pnpm publish:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tsconfig.tsbuildinfo
 
 .claude/*
 !.claude/commands/
+!.claude/settings.json
 
 # Cloudflare Wrangler local state (D1, KV, R2, etc.)
 .wrangler/


### PR DESCRIPTION
## Summary
Set up `.claude/settings.json` with project-level permissions to configure Claude Code's workspace access for the RuleHunt project.

## Changes
- ✨ Add `.claude/settings.json` with permission configuration
- ✅ Allow common development commands (pnpm, git, gh)
- 📖 Allow reading source files, docs, and configuration
- ✏️ Allow editing/writing source files
- 🚫 Deny access to environment files (.env)
- 🚫 Deny destructive operations (rm, curl, wget, publish)
- 📝 Update `.gitignore` to track settings.json while ignoring settings.local.json

## Permission Details

### Allowed Operations
- Build/lint commands: `pnpm run check`, `pnpm run lint`, `pnpm run build:*`
- Git operations: `git *`, `gh *`
- Package management: `pnpm install:*`, `pnpm add:*`
- Reading: source files, documentation, configuration files
- Editing/Writing: source code in `src/`, `functions/`, `scripts/`

### Denied Operations
- Environment files: `.env`, `.env.*`
- Destructive commands: `rm`, `curl`, `wget`
- Publishing: `npm publish`, `pnpm publish`

## Benefits
- Team members get consistent Claude Code experience
- Prevents accidental sensitive file access
- Blocks potentially dangerous operations
- Personal settings still available via `.claude/settings.local.json` (gitignored)

Resolves #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)