### PR TITLE
fix: register Chart.js PieController and BarController

### DIFF
--- a/src/components/desktop/statistics.ts
+++ b/src/components/desktop/statistics.ts
@@ -2,12 +2,14 @@
 
 import {
   ArcElement,
+  BarController,
   BarElement,
   CategoryScale,
   Chart,
   type ChartConfiguration,
   type ChartOptions,
   LinearScale,
+  PieController,
   Title,
   Tooltip,
 } from 'chart.js'
@@ -18,7 +20,9 @@ Chart.register(
   CategoryScale,
   LinearScale,
   BarElement,
+  BarController,
   ArcElement,
+  PieController,
   Title,
   Tooltip,
 )


### PR DESCRIPTION
## Summary
Fixes chart rendering error in Statistics tab where pie and bar charts fail to render with error: `"pie" is not a registered controller`.

## Problem
Chart.js requires explicit registration of controller components. The Statistics panel was importing and registering chart elements (`ArcElement`, `BarElement`) but not the controllers (`PieController`, `BarController`) needed to create pie and bar charts.

## Solution
Added imports and registration for:
- `PieController` - Required for pie charts (Outcome Distribution, Wolfram Classification)
- `BarController` - Required for bar charts (Interest Score, Population, Activity, Entropy distributions)

## Testing
- [x] TypeScript type checking passes
- [x] Biome linting passes
- [ ] Manual testing: Navigate to Statistics tab (Ctrl+4)
- [ ] Manual testing: Click refresh button
- [ ] Manual testing: Verify all 6 charts render correctly (2 pie, 4 bar)

## Files Changed
- `src/components/desktop/statistics.ts` - Added PieController and BarController imports/registration

Resolves the chart rendering error discovered in #77 (Database Statistics Viewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)