### PR TITLE
fix: prevent Chart.js charts from growing unbounded in height

### DIFF
--- a/src/components/desktop/statistics.ts
+++ b/src/components/desktop/statistics.ts
@@ -67,37 +67,49 @@ export function createStatisticsPanel(): {
       <!-- Outcome Distribution (Pie) -->
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-300 dark:border-gray-600">
         <h3 class="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Outcome Distribution</h3>
-        <canvas id="outcome-chart" width="300" height="300"></canvas>
+        <div style="height: 300px; position: relative;">
+          <canvas id="outcome-chart"></canvas>
+        </div>
       </div>
 
       <!-- Wolfram Classification (Pie) -->
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-300 dark:border-gray-600">
         <h3 class="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Wolfram Classification</h3>
-        <canvas id="wolfram-chart" width="300" height="300"></canvas>
+        <div style="height: 300px; position: relative;">
+          <canvas id="wolfram-chart"></canvas>
+        </div>
       </div>
 
       <!-- Interest Score Distribution (Bar) -->
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-300 dark:border-gray-600">
         <h3 class="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Interest Score Distribution</h3>
-        <canvas id="interest-chart" width="400" height="300"></canvas>
+        <div style="height: 300px; position: relative;">
+          <canvas id="interest-chart"></canvas>
+        </div>
       </div>
 
       <!-- Population Distribution (Bar) -->
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-300 dark:border-gray-600">
         <h3 class="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Population Distribution</h3>
-        <canvas id="population-chart" width="400" height="300"></canvas>
+        <div style="height: 300px; position: relative;">
+          <canvas id="population-chart"></canvas>
+        </div>
       </div>
 
       <!-- Activity Distribution (Bar) -->
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-300 dark:border-gray-600">
         <h3 class="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Activity Distribution</h3>
-        <canvas id="activity-chart" width="400" height="300"></canvas>
+        <div style="height: 300px; position: relative;">
+          <canvas id="activity-chart"></canvas>
+        </div>
       </div>
 
       <!-- Entropy Distribution (Bar) -->
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg border border-gray-300 dark:border-gray-600">
         <h3 class="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Entropy Distribution</h3>
-        <canvas id="entropy-chart" width="400" height="300"></canvas>
+        <div style="height: 300px; position: relative;">
+          <canvas id="entropy-chart"></canvas>
+        </div>
       </div>
     </div>
   `
@@ -153,7 +165,8 @@ export function renderStatistics(
   // Common chart options
   const commonOptions: Partial<ChartOptions> = {
     responsive: true,
-    maintainAspectRatio: false,
+    maintainAspectRatio: true,
+    aspectRatio: 2,
     plugins: {
       legend: {
         labels: {
@@ -191,7 +204,8 @@ export function renderStatistics(
     },
     options: {
       responsive: true,
-      maintainAspectRatio: false,
+      maintainAspectRatio: true,
+      aspectRatio: 1,
       plugins: {
         legend: {
           labels: { color: textColor },
@@ -225,7 +239,8 @@ export function renderStatistics(
     },
     options: {
       responsive: true,
-      maintainAspectRatio: false,
+      maintainAspectRatio: true,
+      aspectRatio: 1,
       plugins: {
         legend: {
           labels: { color: textColor },


### PR DESCRIPTION
## Summary
Fixes critical chart rendering issue where charts grow unbounded in height (20,000+ pixels) when rendered or when switching tabs.

## Problem
Chart.js charts were configured with `responsive: true` and `maintainAspectRatio: false`, which causes the canvas to fill its container and grow indefinitely without proper constraints. This resulted in charts rendering at 20,000+ pixel heights.

## Solution
1. **Wrap canvases** in fixed-height containers (300px with `position: relative`)
2. **Set maintainAspectRatio: true** for all charts to prevent unbounded growth
3. **Use appropriate aspect ratios:**
   - Pie charts: `aspectRatio: 1` (square, 1:1)
   - Bar charts: `aspectRatio: 2` (landscape, 2:1 width:height)

This ensures charts:
- Stay at reasonable, consistent sizes
- Don't grow when page is resized
- Don't grow when switching between tabs
- Maintain proper proportions

## Testing
- [x] TypeScript type checking passes
- [x] Biome linting passes (after fixing buildInfo.ts)
- [ ] Manual testing: Navigate to Statistics tab (Ctrl+4)
- [ ] Manual testing: Click refresh button multiple times
- [ ] Manual testing: Switch between tabs and verify charts don't grow
- [ ] Manual testing: Resize browser window and verify charts scale properly

## Files Changed
- `src/components/desktop/statistics.ts` - Fixed canvas containers and chart options

## Before
```html
<canvas id="wolfram-chart" width="619" height="23004" style="height: 23004px; width: 619px;"></canvas>
```

## After
```html
<div style="height: 300px; position: relative;">
  <canvas id="wolfram-chart"></canvas>
</div>
```

Fixes chart sizing issues discovered in #77 (Database Statistics Viewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)