### PR TITLE
fix: set explicit canvas dimensions for consistent chart sizing

### DIFF
--- a/src/components/desktop/statistics.ts
+++ b/src/components/desktop/statistics.ts
@@ -142,6 +142,20 @@ export function renderStatistics(
   const textColor = isDark ? '#f3f4f6' : '#1f2937'
   const gridColor = isDark ? '#374151' : '#e5e7eb'
 
+  // Set explicit canvas dimensions to fill 300px containers
+  const canvases = [
+    elements.outcomeCanvas,
+    elements.wolframCanvas,
+    elements.interestCanvas,
+    elements.populationCanvas,
+    elements.activityCanvas,
+    elements.entropyCanvas,
+  ]
+  for (const canvas of canvases) {
+    canvas.width = 600
+    canvas.height = 300
+  }
+
   // Render summary cards - Automata stats first, then engagement stats
   elements.summaryCards.innerHTML = `
     <!-- Automata Statistics -->


### PR DESCRIPTION
## Problem
Charts in the Statistics tab were rendering at 150px height instead of 300px, appearing smaller than intended.

**Root Cause:** When `responsive: false` is set in Chart.js options (to prevent the continuous growth issue from PR #79), Chart.js no longer auto-sizes canvases to their container dimensions.

## Solution
Explicitly set `canvas.width = 600` and `canvas.height = 300` for all chart canvases before creating the Chart instances. This ensures charts fill their 300px-height containers properly.

## Files Changed
- `src/components/desktop/statistics.ts`: Added explicit canvas dimension setting in `renderStatistics()` function

## Test Plan
- [x] TypeScript type checking passes
- [ ] Manual testing: Navigate to Statistics tab (Ctrl+4)
- [ ] Manual testing: Click refresh and verify all charts render at full 300px height
- [ ] Manual testing: Verify charts don't grow continuously after rendering

## Related
- Fixes regression introduced by responsive: false in PR #79
- Companion to PR #81 (user engagement metrics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)