### PR TITLE
chore: consolidate duplicate CleanupFunction type definition

### DIFF
--- a/src/components/desktop/dataMode.ts
+++ b/src/components/desktop/dataMode.ts
@@ -1,5 +1,6 @@
 // src/components/dataMode.ts
 
+import type { CleanupFunction } from '../../types'
 import type { DataModeState } from '../../dataRunner'
 import { runDataLoop } from '../../dataRunner'
 import {
@@ -12,8 +13,6 @@ import type { C4OrbitsData } from '../../schema'
 import { buildOrbitLookup } from '../../utils'
 import { createHeader, setupTheme } from './header'
 import { createProgressBar } from './progressBar'
-
-export type CleanupFunction = () => void
 
 export async function setupDataModeLayout(
   appRoot: HTMLDivElement,

--- a/src/components/desktop/header.ts
+++ b/src/components/desktop/header.ts
@@ -1,5 +1,7 @@
 // src/components/header.ts
 
+import type { CleanupFunction } from '../../types'
+
 export interface ThemeToggleElements {
   light: HTMLButtonElement
   dark: HTMLButtonElement
@@ -13,7 +15,6 @@ export interface HeaderElements {
 }
 
 export type Theme = 'light' | 'dark' | 'system'
-export type CleanupFunction = () => void
 
 export function createHeader(): {
   root: HTMLElement

--- a/src/components/desktop/layout.ts
+++ b/src/components/desktop/layout.ts
@@ -1,3 +1,4 @@
+import type { CleanupFunction } from '../../types'
 import { saveRun } from '../../api/save'
 import { CellularAutomata } from '../../cellular-automata-cpu.ts'
 import { outlierRule } from '../../outlier-rule.ts'
@@ -44,7 +45,6 @@ const GRID_ROWS = 400
 const GRID_COLS = 400
 
 // --- Types -----------------------------------------------------------------
-export type CleanupFunction = () => void
 type DisplayMode = 'orbits' | 'full'
 
 // --- Color Management ------------------------------------------------------

--- a/src/components/mobile/buttonContainer.ts
+++ b/src/components/mobile/buttonContainer.ts
@@ -5,7 +5,7 @@
  * Separates layout/behavior concerns from button implementation.
  */
 
-export type CleanupFunction = () => void
+import type { CleanupFunction } from '../../types'
 
 export interface ButtonContainerPosition {
   top?: string

--- a/src/components/mobile/header.ts
+++ b/src/components/mobile/header.ts
@@ -1,13 +1,13 @@
 // src/components/mobileHeader.ts
 
+import type { CleanupFunction } from '../../types'
+
 export interface MobileHeaderElements {
   titleElement: HTMLHeadingElement
   infoButton: HTMLButtonElement
   infoOverlay: HTMLDivElement
   closeButton: HTMLButtonElement
 }
-
-export type CleanupFunction = () => void
 
 export function createMobileHeader(): {
   root: HTMLElement

--- a/src/components/mobile/layout.ts
+++ b/src/components/mobile/layout.ts
@@ -73,7 +73,7 @@ const DARK_FG_COLORS = [
 
 // --- Types ------------------------------------------------------------------
 
-export type CleanupFunction = () => void
+import type { CleanupFunction } from '../../types'
 
 // Runtime rule container used only on mobile.ts.
 // Combines a C4 or expanded ruleset plus optional cached expansion.

--- a/src/components/mobile/statsOverlay.ts
+++ b/src/components/mobile/statsOverlay.ts
@@ -1,5 +1,6 @@
 // src/components/statsOverlay.ts
 
+import type { CleanupFunction } from '../../types'
 import type { RunSubmission } from '../../schema.ts'
 import {
   generateSimulationMetricsHTML,
@@ -17,8 +18,6 @@ export interface StatsOverlayElements {
   closeButton: HTMLButtonElement
   content: HTMLDivElement
 }
-
-export type CleanupFunction = () => void
 
 export function createStatsOverlay(parentElement?: HTMLElement): {
   elements: StatsOverlayElements

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,5 @@
-import {
-  type CleanupFunction,
-  setupDesktopLayout,
-} from './components/desktop/layout.ts'
+import type { CleanupFunction } from './types'
+import { setupDesktopLayout } from './components/desktop/layout.ts'
 import { applyThemeFromStorage } from './components/desktop/theme'
 import { setupMobileLayout } from './components/mobile/layout.ts'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+/**
+ * Function signature for cleanup operations.
+ * Returns a function that cleans up event listeners, timers, etc.
+ */
+export type CleanupFunction = () => void


### PR DESCRIPTION
## Summary

Consolidates 7 duplicate `CleanupFunction` type definitions into a single shared type in `src/types.ts`. This reduces code duplication and establishes a pattern for managing shared types project-wide.

## Changes Made

**Created:**
- `src/types.ts` - New shared types file with `CleanupFunction` export

**Updated (7 files):**
- `src/components/mobile/buttonContainer.ts`
- `src/components/mobile/header.ts`
- `src/components/mobile/layout.ts`
- `src/components/mobile/statsOverlay.ts`
- `src/components/desktop/header.ts`
- `src/components/desktop/dataMode.ts`
- `src/components/desktop/layout.ts`
- `src/main.ts` - Updated import path

Each file now imports `CleanupFunction` from `../../types` instead of defining it locally.

## Benefits

- **Single Source of Truth**: One place to maintain cleanup function type
- **Consistency**: Guaranteed identical signature across all uses
- **Future-Proof**: If cleanup signature needs to change (e.g., async cleanup), only one edit needed
- **Standard Pattern**: Follows typical TypeScript project structure for shared types

## Test Plan

### Type Safety Verification
- [x] TypeScript type check passes (`pnpm check`)
- [x] Build succeeds (`pnpm build`)
- [x] All imports resolve correctly
- [x] No type errors

### Runtime Verification
Manual testing completed:
- [x] Mobile layout loads without errors
- [x] Desktop layout loads without errors
- [x] Header cleanup functions work (theme toggle)
- [x] Stats overlay cleanup works
- [x] Button container cleanup works

## Risk Assessment

**Risk Level**: Very Low
- Pure type-level change (no runtime impact)
- TypeScript compiler validates all imports at build time
- Zero risk of introducing bugs (types don't execute)

## Related

Resolves #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>