### PR TITLE
Add sound controls and volume slider to desktop header

### DIFF
--- a/src/components/desktop/header.ts
+++ b/src/components/desktop/header.ts
@@ -1,14 +1,22 @@
 // src/components/header.ts
 
+import {
+  type SoundControlsElements,
+  createSoundControls,
+} from './soundControls'
 import type { ThemeToggleElements } from './theme'
 
 export interface HeaderElements {
   themeToggle: ThemeToggleElements
   githubLink: HTMLAnchorElement
   mobilePreviewButton?: HTMLButtonElement
+  soundControls: SoundControlsElements
 }
 
-export function createHeader(): {
+export function createHeader(
+  onSoundToggle: (enabled: boolean) => void,
+  onVolumeChange: (volume: number) => void,
+): {
   root: HTMLElement
   elements: HeaderElements
 } {
@@ -28,8 +36,8 @@ export function createHeader(): {
         </span>
       </div>
 
-      <!-- Right: Mobile Preview + GitHub + Theme Toggle -->
-      <div class="flex items-center gap-4">
+      <!-- Right: Mobile Preview + Sound Controls + GitHub + Theme Toggle -->
+      <div id="header-controls" class="flex items-center gap-4">
         <!-- Mobile Preview Button (hidden on actual mobile) -->
         <button
           id="mobile-preview-button"
@@ -39,6 +47,8 @@ export function createHeader(): {
           <span class="text-lg">📱</span>
           <span class="hidden lg:inline">Mobile Preview</span>
         </button>
+
+        <!-- Sound Controls placeholder (will be inserted here) -->
 
         <!-- GitHub Link -->
         <a
@@ -65,6 +75,14 @@ export function createHeader(): {
     </div>
   `
 
+  // Create sound controls and insert them after mobile preview button
+  const soundControls = createSoundControls(onSoundToggle, onVolumeChange)
+  const headerControls = root.querySelector('#header-controls')
+  const githubLink = root.querySelector('#github-link')
+  if (headerControls && githubLink) {
+    headerControls.insertBefore(soundControls.root, githubLink)
+  }
+
   const elements: HeaderElements = {
     themeToggle: {
       light: root.querySelector('#theme-light') as HTMLButtonElement,
@@ -75,6 +93,7 @@ export function createHeader(): {
     mobilePreviewButton: root.querySelector(
       '#mobile-preview-button',
     ) as HTMLButtonElement,
+    soundControls: soundControls.elements,
   }
 
   return { root, elements }

--- a/src/components/desktop/soundControls.ts
+++ b/src/components/desktop/soundControls.ts
@@ -1,0 +1,96 @@
+// src/components/desktop/soundControls.ts
+
+/**
+ * Creates sound controls for the desktop header.
+ * Provides on/off toggle and volume slider for CA sonification.
+ */
+
+export interface SoundControlsElements {
+  toggleButton: HTMLButtonElement
+  volumeSlider: HTMLInputElement
+  volumeValue: HTMLSpanElement
+}
+
+export function createSoundControls(
+  onToggle: (enabled: boolean) => void,
+  onVolumeChange: (volume: number) => void,
+): { root: HTMLDivElement; elements: SoundControlsElements } {
+  // Get initial state from localStorage
+  const soundEnabled = localStorage.getItem('sound-enabled') === 'true'
+  const soundVolume = localStorage.getItem('sound-volume') || '30'
+
+  const root = document.createElement('div')
+  root.className =
+    'flex items-center gap-2 px-3 py-1.5 rounded-md border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 transition-colors'
+
+  root.innerHTML = `
+    <button
+      id="sound-toggle"
+      class="text-lg transition-opacity hover:opacity-80"
+      aria-label="${soundEnabled ? 'Disable sound' : 'Enable sound'}"
+      title="${soundEnabled ? 'Disable sound' : 'Enable sound'}"
+    >
+      ${soundEnabled ? '🔊' : '🔇'}
+    </button>
+    <input
+      type="range"
+      id="volume-slider"
+      min="0"
+      max="100"
+      step="1"
+      value="${soundVolume}"
+      ${soundEnabled ? '' : 'disabled'}
+      class="w-20 accent-violet-600 dark:accent-violet-400 disabled:opacity-30 disabled:cursor-not-allowed"
+      aria-label="Volume level"
+      title="Volume: ${soundVolume}%"
+    />
+    <span
+      id="volume-value"
+      class="text-xs font-medium text-gray-700 dark:text-gray-300 w-10 text-right"
+    >
+      ${soundVolume}%
+    </span>
+  `
+
+  const elements: SoundControlsElements = {
+    toggleButton: root.querySelector('#sound-toggle') as HTMLButtonElement,
+    volumeSlider: root.querySelector('#volume-slider') as HTMLInputElement,
+    volumeValue: root.querySelector('#volume-value') as HTMLSpanElement,
+  }
+
+  // Toggle button handler
+  elements.toggleButton.addEventListener('click', () => {
+    const newState = localStorage.getItem('sound-enabled') !== 'true'
+    localStorage.setItem('sound-enabled', String(newState))
+
+    // Update button UI
+    elements.toggleButton.textContent = newState ? '🔊' : '🔇'
+    elements.toggleButton.setAttribute(
+      'aria-label',
+      newState ? 'Disable sound' : 'Enable sound',
+    )
+    elements.toggleButton.title = newState ? 'Disable sound' : 'Enable sound'
+
+    // Enable/disable slider
+    elements.volumeSlider.disabled = !newState
+
+    // Notify callback
+    onToggle(newState)
+  })
+
+  // Volume slider handler
+  elements.volumeSlider.addEventListener('input', () => {
+    const volume = elements.volumeSlider.value
+    localStorage.setItem('sound-volume', volume)
+
+    // Update volume display
+    elements.volumeValue.textContent = `${volume}%`
+    elements.volumeSlider.title = `Volume: ${volume}%`
+
+    // Notify callback (convert 0-100 to 0-1 range)
+    const volumeDecimal = Number.parseInt(volume) / 100
+    onVolumeChange(volumeDecimal)
+  })
+
+  return { root, elements }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive audio controls to the desktop version, enabling users to control cellular automata sonification with on/off toggle and volume slider. This provides desktop users with the same (and enhanced) audio control that mobile users have, while matching the existing header design patterns.

## Changes

**New Component:** `src/components/desktop/soundControls.ts`
- Sound on/off toggle button (🔇/🔊)
- Volume slider (0-100%)
- Volume percentage display
- localStorage persistence (sound-enabled, sound-volume)
- Callbacks for toggle and volume changes
- Accessible ARIA labels and semantic HTML
- Tailwind CSS styling matching existing header controls

**Updated:** `src/components/desktop/header.ts`
- Added soundControls to HeaderElements interface
- Modified createHeader() to accept onSoundToggle and onVolumeChange callbacks
- Integrated soundControls component between Mobile Preview button and GitHub link

**Updated:** `src/components/desktop/layout.ts`
- Imported AudioEngine
- Created AudioEngine instance with localStorage-based initialization
- Implemented handleSoundToggle() and handleVolumeChange() callbacks
- Passed callbacks to createHeader()
- Updated updateStatisticsDisplay() to update AudioEngine with CA statistics
- Added AudioEngine cleanup in layout teardown function
- Sound state restored from localStorage on page load

## Test Plan

✅ **CI Checks**: All TypeScript and lint checks pass
✅ **Visual Integration**: Sound controls appear in desktop header with consistent styling
✅ **Toggle Functionality**: Button switches between 🔇 (off) and 🔊 (on)
✅ **Volume Slider**: Slider enabled when sound on, disabled when off
✅ **localStorage Persistence**: Settings persist across page reloads
✅ **AudioEngine Integration**: Audio plays when enabled, matches slider volume
✅ **Real-time Updates**: AudioEngine receives CA statistics updates
✅ **Accessibility**: ARIA labels present, keyboard navigation works
✅ **Cleanup**: AudioEngine properly torn down on layout cleanup

## Related Issues

Closes #136

## Additional Notes

- Default state: Sound OFF, Volume 30% (per #137 mobile sounds removal)
- AudioEngine already had volume API - no modifications needed
- Follows existing component patterns (similar to mobile soundToggle.ts)
- No breaking changes - purely additive feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>