### PR TITLE
fix: prevent canvas createImageData errors with invalid dimensions

### DIFF
--- a/src/cellular-automata-base.ts
+++ b/src/cellular-automata-base.ts
@@ -81,7 +81,7 @@ export abstract class CellularAutomataBase {
     this.grid = new Uint8Array(this.gridArea)
     this.statistics = new StatisticsTracker(this.gridRows, this.gridCols)
 
-    if (this.ctx) {
+    if (this.ctx && this.gridCols > 0 && this.gridRows > 0) {
       this.imageData = this.ctx.createImageData(this.gridCols, this.gridRows)
       this.pixelData = this.imageData.data
     } else {
@@ -455,6 +455,14 @@ export abstract class CellularAutomataBase {
     if (this.canvas) {
       this.canvas.width = this.canvas.clientWidth
       this.canvas.height = this.canvas.clientHeight
+    }
+
+    // Guard against invalid dimensions
+    if (newRows <= 0 || newCols <= 0) {
+      console.warn(
+        `[resize] Invalid grid dimensions: ${newCols}×${newRows} - skipping resize`,
+      )
+      return
     }
 
     this.gridRows = newRows

--- a/src/components/mobile/layout.ts
+++ b/src/components/mobile/layout.ts
@@ -101,6 +101,21 @@ function computeAdaptiveGrid(
     ? containerElement.clientHeight
     : window.innerHeight
 
+  // Guard against zero or negative screen dimensions
+  if (screenWidth <= 0 || screenHeight <= 0) {
+    console.warn(
+      `[computeAdaptiveGrid] Invalid screen dimensions: ${screenWidth}×${screenHeight} - using fallback`,
+    )
+    return {
+      gridCols: 100,
+      gridRows: 100,
+      cellSize: 1,
+      totalCells: 10000,
+      screenWidth: 100,
+      screenHeight: 100,
+    }
+  }
+
   let cellSize = 1
   let gridCols = screenWidth
   let gridRows = screenHeight
@@ -112,6 +127,12 @@ function computeAdaptiveGrid(
     gridRows = Math.floor(screenHeight / cellSize)
     totalCells = gridCols * gridRows
   }
+
+  // Ensure we never return 0 dimensions
+  gridCols = Math.max(1, gridCols)
+  gridRows = Math.max(1, gridRows)
+  totalCells = gridCols * gridRows
+
   return { gridCols, gridRows, cellSize, totalCells, screenWidth, screenHeight }
 }
 


### PR DESCRIPTION
## Summary
- Fix DOMException errors in production caused by `createImageData` with invalid dimensions
- Add dimension validation guards in `CellularAutomataBase` constructor and resize method
- Add fallback and minimum dimension guarantees in `computeAdaptiveGrid`

## Problem
Production logs showed `Uncaught DOMException: CanvasRenderingContext2D.createImageData: Invalid width or height` errors occurring when:
- Canvas elements hadn't been laid out yet (clientWidth/clientHeight = 0)
- Resize events fired during page initialization
- Edge cases with browser window sizing

## Solution
### 1. Guard in constructor (cellular-automata-base.ts:84)
Only create ImageData when grid dimensions are valid:
```typescript
if (this.ctx && this.gridCols > 0 && this.gridRows > 0) {
  this.imageData = this.ctx.createImageData(this.gridCols, this.gridRows)
}
```

### 2. Guard in resize method (cellular-automata-base.ts:460)
Skip resize operations when dimensions are invalid:
```typescript
if (newRows <= 0 || newCols <= 0) {
  console.warn(`[resize] Invalid grid dimensions: ${newCols}×${newRows} - skipping resize`)
  return
}
```

### 3. Defensive grid computation (mobile/layout.ts:104-136)
- Return fallback dimensions when screen size is invalid
- Ensure minimum 1×1 grid with `Math.max(1, gridCols/gridRows)`

## Test plan
- [x] Tested with headless browser (Puppeteer) across multiple viewport sizes
- [x] Verified no canvas errors during rapid resize events
- [x] Confirmed dev server hot reload works correctly
- [ ] Manual testing in production environment
- [ ] Verify no regressions in canvas rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)