### PR TITLE
Remove commented-out imports from summary.ts

### DIFF
--- a/src/components/desktop/summary.ts
+++ b/src/components/desktop/summary.ts
@@ -1,8 +1,5 @@
 // src/components/summary.ts
 
-// import { generateSimulationMetricsHTML } from './shared/simulationInfo.ts'
-// import { generateStatsHTML } from './shared/stats.ts'
-
 export interface SummaryPanelElements {
   metricsContainer: HTMLDivElement
   statsContainer: HTMLDivElement


### PR DESCRIPTION
## Summary

Removes two commented-out import statements from `src/components/desktop/summary.ts` that have been unused since the October 11 refactor.

## Changes

- Removed lines 3-4: commented-out imports for `generateSimulationMetricsHTML` and `generateStatsHTML`
- These functions are still used elsewhere in the codebase but not in this file

## Benefits

- **Visual Clarity**: Cleaner imports section without dead code
- **Reduced Confusion**: Makes it clear what the file actually depends on
- **Maintenance**: Eliminates potential confusion about whether these imports should be uncommented

## Test Plan

✅ TypeScript check passed (`pnpm check`)
✅ Linting passed (`pnpm lint`)
✅ All 130 tests passed (`pnpm test`)

## Risk Assessment

**Risk Level**: Low - These lines were already commented out, so removing them has zero functional impact.

Closes #155