### PR TITLE
Remove commented-out setInterval wrapper

### DIFF
--- a/src/components/desktop/layout.ts
+++ b/src/components/desktop/layout.ts
@@ -111,13 +111,6 @@ export async function setupDesktopLayout(
     })
   }
 
-  // Interval tracking for cleanup (currently unused but kept for future use)
-  // const setInterval = (handler: () => void, ms: number): number => {
-  //   const id = window.setInterval(handler, ms)
-  //   intervals.push(id)
-  //   return id
-  // }
-
   const clearInterval = (id: number) => {
     window.clearInterval(id)
     const index = intervals.indexOf(id)


### PR DESCRIPTION
## Summary

Remove commented-out `setInterval` wrapper function (lines 114-119 in `src/components/desktop/layout.ts`) that was marked as "currently unused but kept for future use".

This follows the YAGNI (You Aren't Gonna Need It) principle.

## Changes

- ✅ Deleted 6 lines of commented-out code
- ✅ Kept `clearInterval` function and `intervals` array (still in use)
- ✅ No behavioral changes (code was commented out)

## Verification

**Pre-removal checks:**
```bash
# Verified commented code was never used
rg "setInterval\(" src/components/desktop/layout.ts
# Only found the commented-out definition
```

**Post-removal checks:**
```bash
# TypeScript compilation (pre-existing error unrelated to changes)
pnpm run check
# ✅ No new errors introduced

# Linting
pnpm run lint
# ✅ Passed with no issues

# Test suite
pnpm test
# ✅ All 203 tests passed
```

## Context

- Added in PR #151 (Oct 21, 2025) as "future use" safety net
- Never actually used since being added
- Cleanup infrastructure (`clearInterval`, `intervals` array) works fine without it
- If needed in the future, can be re-added when there's a concrete use case

Closes #183

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>