### PR TITLE
fix: remove unused resetTransforms function in swipeHandlers

### DIFF
--- a/src/components/mobile/events/swipeHandlers.ts
+++ b/src/components/mobile/events/swipeHandlers.ts
@@ -94,12 +94,6 @@ export function setupDualCanvasSwipe(
       : { onScreen: canvas2, offScreen: canvas1 }
   }
 
-  const resetTransforms = (h: number) => {
-    const { onScreen, offScreen } = getCurrentCanvases()
-    onScreen.style.transform = 'translateY(0)'
-    offScreen.style.transform = `translateY(${h}px)`
-  }
-
   function waitForTransitionEndScoped(
     el: HTMLElement,
     id: number,


### PR DESCRIPTION
## Summary
- Removed unused `resetTransforms` helper function that was causing TypeScript build error (TS6133)
- The function was declared but never called, as transform resets are handled inline throughout the file

## Changes
- Removed `resetTransforms` function from `src/components/mobile/events/swipeHandlers.ts:97`

## Test plan
- [x] Build completes successfully with `pnpm run build`
- [x] No TypeScript errors

Fixes the build error:
```
src/components/mobile/events/swipeHandlers.ts(97,9): error TS6133: 'resetTransforms' is declared but its value is never read.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)