### PR TITLE
Add API endpoint for database export

### DIFF
--- a/functions/api/export-database.ts
+++ b/functions/api/export-database.ts
@@ -1,0 +1,49 @@
+/// <reference types="@cloudflare/workers-types" />
+import type { D1Database, EventContext } from '@cloudflare/workers-types'
+
+export const onRequestGet = async (
+  ctx: EventContext<{ DB: D1Database }, string, Record<string, unknown>>,
+): Promise<Response> => {
+  try {
+    const db = ctx.env.DB
+
+    // Fetch all runs
+    const stmt = db.prepare('SELECT * FROM runs ORDER BY submitted_at DESC')
+    const result = await stmt.all()
+
+    // Convert to CSV
+    const rows = result.results as Record<string, unknown>[]
+    if (rows.length === 0) {
+      return new Response('No data available', { status: 404 })
+    }
+
+    // Generate CSV header
+    const headers = Object.keys(rows[0])
+    const csvHeader = headers.join(',')
+
+    // Generate CSV rows with proper escaping
+    const csvRows = rows.map(row =>
+      headers.map(header => {
+        const value = row[header]
+        const str = String(value ?? '')
+        return str.includes(',') || str.includes('"') || str.includes('\n')
+          ? `"${str.replace(/"/g, '""')}"`
+          : str
+      }).join(',')
+    )
+
+    const csv = [csvHeader, ...csvRows].join('\n')
+
+    // Return as downloadable file
+    return new Response(csv, {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="rulehunt-export-${new Date().toISOString().split('T')[0]}.csv"`,
+        'Cache-Control': 'public, max-age=86400'
+      }
+    })
+  } catch (err) {
+    console.error('[export-database] Error:', err)
+    return new Response('Export failed', { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of the research data export feature (#197) by adding a Cloudflare Pages Function that exports the complete `runs` table as a downloadable CSV file.

## Changes

- **New file**: `functions/api/export-database.ts` - API endpoint for database export
- Exports all simulation runs from D1 database ordered by submission date
- Generates RFC 4180 compliant CSV with proper character escaping
- Returns file with date-stamped filename: `rulehunt-export-YYYY-MM-DD.csv`
- Includes 24-hour cache control header for performance
- Graceful error handling (404 for empty database, 500 for failures)

## Technical Details

**Endpoint**: `GET /api/export-database`

**Features**:
- SQL query: `SELECT * FROM runs ORDER BY submitted_at DESC`
- CSV escaping for commas, quotes, and newlines
- Content-Type: `text/csv; charset=utf-8`
- Content-Disposition: attachment with datestamped filename
- Console logging for errors

**Matches existing patterns**:
- Uses same D1 database access pattern as `save.ts` and `statistics.ts`
- Uses EventContext type with inline Env definition
- Follows established error handling conventions

## Test Plan

- [x] TypeScript compilation passes
- [x] Biome lint passes  
- [x] Code structure matches existing API endpoints
- [ ] Manual test: Start dev server and curl endpoint (ready for testing after merge)
- [ ] Verify CSV format with real database data
- [ ] Verify Content-Disposition triggers browser download

## Dependencies

None - standalone API endpoint

## Next Steps

After this PR merges, Phase 2 (#203) will add the Research tab UI with a download button that links to this endpoint.

Closes #202