### PR TITLE
Update checkbox tooltip to clarify manual reset behavior

### DIFF
--- a/src/components/desktop/simulation.ts
+++ b/src/components/desktop/simulation.ts
@@ -42,7 +42,7 @@ export function createSimulationPanel(): {
           <span>Center Seed</span>
         </label>
         <hr class="border-gray-300 dark:border-gray-600 my-1" />
-        <label class="flex items-center gap-2 text-sm cursor-pointer px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors" title="When enabled, each reset generates a new random pattern. When disabled, resets reuse the same initial conditions for reproducible testing.">
+        <label class="flex items-center gap-2 text-sm cursor-pointer px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors" title="Controls manual reset behavior. When enabled, each reset generates a new random pattern. When disabled, resets reuse the same seed for reproducible testing. Does NOT affect automatic mutation.">
           <input type="checkbox" id="checkbox-new-pattern-on-reset" checked class="cursor-pointer" />
           <span>Generate new pattern on reset</span>
         </label>


### PR DESCRIPTION
## Summary

Updates the "Generate new pattern on reset" checkbox tooltip to prevent user confusion with the upcoming auto-mutation feature.

## Changes

**File**: `src/components/desktop/simulation.ts:45`

**Before**:
> When enabled, each reset generates a new random pattern. When disabled, resets reuse the same initial conditions for reproducible testing.

**After**:
> Controls manual reset behavior. When enabled, each reset generates a new random pattern. When disabled, resets reuse the same seed for reproducible testing. Does NOT affect automatic mutation.

**What changed**:
- ✅ Added "Controls manual reset behavior" prefix for context
- ✅ Changed "initial conditions" → "seed" (more precise)
- ✅ Added "Does NOT affect automatic mutation" disclaimer

## Why This Matters

Once auto-mutation is implemented (#199 + #200), users will have TWO checkboxes:
1. **"Generate new pattern on reset"** - Manual reset button behavior (this one)
2. **"Auto-mutate ruleset on completion"** - Automatic mutation cycle (upcoming)

Without this clarification, users might assume the first checkbox controls both manual AND automatic behavior, causing confusion when the auto-mutation feature doesn't work as expected.

## Test Plan

- [x] Biome lint passes
- [x] Single attribute change (no functional changes)
- [ ] Manual verification: Hover over checkbox to see updated tooltip text
- [x] No tests required (presentation-only update)

## Dependencies

None - independent polish, can merge anytime

## Related

- Part of Phase 3 from parent issue #198
- Complements #199 (checkbox UI) and #200 (auto-mutation logic)

Closes #201