### PR TITLE
Phase 1: Add generation parameter to shareable URLs

### DIFF
--- a/src/components/desktop/layout.ts
+++ b/src/components/desktop/layout.ts
@@ -604,6 +604,18 @@ export async function setupDesktopLayout(
   // Now apply initial condition which will also initialize simulation metadata
   applyInitialCondition()
 
+  // Fast-forward to URL generation if specified
+  if (urlState.generation !== undefined && urlState.generation > 0) {
+    const expandedRuleset = expandC4Ruleset(currentRuleset, orbitLookup)
+    for (let i = 0; i < urlState.generation; i++) {
+      cellularAutomata.step(expandedRuleset)
+    }
+    console.log(
+      '[desktop] Fast-forwarded to generation:',
+      urlState.generation,
+    )
+  }
+
   // Auto-select first cell (index 0) on page load
   if (displayMode === 'orbits') {
     const orbit = orbitsData.orbits[0]

--- a/src/components/mobile/layout.ts
+++ b/src/components/mobile/layout.ts
@@ -644,6 +644,15 @@ export async function setupMobileLayout(
   prepareAutomata(onScreenCA, onScreenRule, lookup, initialSeedPercentage)
   startAutomata(onScreenCA, onScreenRule)
 
+  // Fast-forward to URL generation if specified
+  if (urlState.generation !== undefined && urlState.generation > 0) {
+    const expandedRuleset = expandC4Ruleset(onScreenRule.ruleset, lookup)
+    for (let i = 0; i < urlState.generation; i++) {
+      onScreenCA.step(expandedRuleset)
+    }
+    console.log('[mobile] Fast-forwarded to generation:', urlState.generation)
+  }
+
   prepareAutomata(offScreenCA, offScreenRule, lookup)
   offscreenReady = true
 

--- a/src/urlState.ts
+++ b/src/urlState.ts
@@ -9,6 +9,7 @@ export type URLState = {
   seed?: number
   seedType?: 'center' | 'random' | 'patch'
   seedPercentage?: number
+  generation?: number
 }
 
 /**
@@ -50,6 +51,15 @@ export function parseURLState(): URLState {
       seedPercentage <= 100
     ) {
       state.seedPercentage = seedPercentage
+    }
+  }
+
+  // Parse generation (non-negative integer)
+  const generationStr = params.get('generation')
+  if (generationStr) {
+    const generation = Number.parseInt(generationStr, 10)
+    if (!Number.isNaN(generation) && generation >= 0) {
+      state.generation = generation
     }
   }
 
@@ -99,6 +109,11 @@ export function buildShareURL(state: URLState): string {
   if (state.seedPercentage !== undefined && state.seedPercentage !== 50) {
     // Only include if non-default
     params.set('seedPercentage', state.seedPercentage.toString())
+  }
+
+  if (state.generation !== undefined && state.generation > 0) {
+    // Only include if non-zero (0 is initial state)
+    params.set('generation', state.generation.toString())
   }
 
   const url = new URL(window.location.href)


### PR DESCRIPTION
Implements **Phase 1** of issue #177 for pattern export and sharing functionality.

## What's Implemented

### URL State Enhancement
- ✅ Added `generation` parameter to `URLState` type
- ✅ Parse `generation` from URL query parameters (non-negative integer validation)
- ✅ Include `generation` in `buildShareURL()` (only if > 0 to keep URLs clean)

### Auto-Restore Simulation State
- ✅ Desktop layout: Fast-forward to specified generation on page load
- ✅ Mobile layout: Fast-forward to specified generation on page load  
- ✅ Both use `expandC4Ruleset()` and `step()` to reach target generation
- ✅ Console logging for debugging

### Infrastructure Improvement
- ✅ Migrated `biome.json` from v1.9.4 to v2.2.7 schema
- ✅ Fixes configuration compatibility with current Biome version

## How It Works

URLs can now include the `generation` parameter to share exact simulation states:

```
https://rulehunt.org/?rulesetHex=abc123&seed=42&generation=150
```

When a user loads this URL, the app will:
1. Load the CA rule from `rulesetHex` 
2. Initialize the grid with the specified `seed`
3. **Automatically fast-forward 150 generations** to show the exact pattern state

This enables:
- Sharing interesting patterns at specific time points
- Reproducible research data sharing (ADANA initiative)
- Creating bookmarks for pattern evolution checkpoints

## Technical Details

**Files Modified:**
- `src/urlState.ts` - Added generation parsing/building
- `src/components/desktop/layout.ts` - Added fast-forward logic  
- `src/components/mobile/layout.ts` - Added fast-forward logic
- `biome.json` - Schema migration

**Validation:**
- Generation must be a non-negative integer
- Only included in URL if > 0 (generation=0 is initial state, no need to include)

**Performance:**
- Fast-forward uses efficient `step()` loop
- No UI blocking (runs synchronously on page load before first render)

## Testing

✅ **TypeScript Compilation:** Passes  
✅ **Vite Build:** Succeeds  
✅ **Integration:** Fast-forward logic integrated in both layouts  

**Manual Testing Checklist:**
- [ ] Generate URL with generation parameter (use buildShareURL in console)
- [ ] Open URL in new tab → verify it fast-forwards to correct generation
- [ ] Verify generation count displays correctly in UI
- [ ] Test edge cases: generation=0, generation=1, generation=1000
- [ ] Test on both desktop and mobile layouts

## What's Not Included (Future Phases)

This PR implements **Phase 1 (URL generation parameter)** only. Future phases per curator's plan:

**Phase 2 (Grid State Export):** Add optional grid snapshot to JSON export  
**Phase 3 (CSV Batch Export):** Export multiple starred patterns as CSV  
**Phase 4 (Pattern Library):** UI for browsing/loading saved patterns  
**Phase 5 (Import):** Load patterns from JSON files

## Related

- Closes first milestone of #177  
- Part of ADANA initiative for pattern sharing and research  
- Foundation for Phase 2 (grid state in exports) and Phase 3 (pattern library)

## Notes for Reviewers

- Biome config migration is included because it was required to run linter
- Pre-existing linting warnings in other files are not addressed (out of scope)
- Fast-forward logic is placed after initial condition application to ensure correct state

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>