### PR TITLE
feat: add favorites browser UI for accessing starred patterns

### DIFF
--- a/functions/api/favorites.ts
+++ b/functions/api/favorites.ts
@@ -1,0 +1,69 @@
+/// <reference types="@cloudflare/workers-types" />
+import type { D1Database, EventContext } from '@cloudflare/workers-types'
+import { FavoritesResponse } from '../../src/schema'
+import { handleApiError, jsonResponse } from '../utils/api-helpers'
+
+/**
+ * GET /api/favorites
+ *
+ * Fetches all starred patterns from the database with pagination.
+ * Returns { ok: true, favorites: [...], count: N, hasMore: boolean }
+ *
+ * Query parameters:
+ * - userId: string (default: 'anonymous')
+ * - limit: number (default: 50, max: 100)
+ * - offset: number (default: 0)
+ */
+export const onRequestGet = async (
+  ctx: EventContext<{ DB: D1Database }, string, Record<string, unknown>>,
+): Promise<Response> => {
+  try {
+    const url = new URL(ctx.request.url)
+    const userId = url.searchParams.get('userId') || 'anonymous'
+    const limit = Math.min(
+      parseInt(url.searchParams.get('limit') || '50'),
+      100,
+    )
+    const offset = parseInt(url.searchParams.get('offset') || '0')
+
+    // --- Query for starred patterns with pagination ---
+    const query = `
+      SELECT
+        ruleset_name,
+        ruleset_hex,
+        seed,
+        seed_type,
+        seed_percentage
+      FROM runs
+      WHERE user_id = ? AND is_starred = 1
+      ORDER BY submitted_at DESC
+      LIMIT ? OFFSET ?
+    `
+
+    const { results } = await ctx.env.DB.prepare(query)
+      .bind(userId, limit + 1, offset) // Fetch one extra to check if there are more
+      .all()
+
+    // Check if there are more results
+    const hasMore = results.length > limit
+    const favorites = hasMore ? results.slice(0, limit) : results
+
+    // Ensure seed_percentage is null if not provided (compatibility)
+    for (const favorite of favorites) {
+      if (favorite.seed_percentage === undefined) {
+        favorite.seed_percentage = null
+      }
+    }
+
+    const response = FavoritesResponse.parse({
+      ok: true,
+      favorites,
+      count: favorites.length,
+      hasMore,
+    })
+
+    return jsonResponse(response)
+  } catch (error) {
+    return handleApiError(error, 'favorites')
+  }
+}

--- a/src/api/favorites.ts
+++ b/src/api/favorites.ts
@@ -1,0 +1,61 @@
+// src/api/favorites.ts
+import { type FavoritesResponse, FavoritesResponse as FavoritesResponseSchema } from '../schema'
+
+/**
+ * Fetch all starred patterns from the database with pagination.
+ * Returns null on error.
+ * Validates and parses response using shared Zod schema.
+ *
+ * @param userId - User ID (default: 'anonymous')
+ * @param limit - Number of results to fetch (default: 50, max: 100)
+ * @param offset - Pagination offset (default: 0)
+ * @returns FavoritesResponse with array of patterns, count, and hasMore flag, or null
+ */
+export async function fetchFavorites(
+  userId: string = 'anonymous',
+  limit: number = 50,
+  offset: number = 0,
+): Promise<FavoritesResponse | null> {
+  console.log('[fetchFavorites] 📤 Fetching favorites...', { userId, limit, offset })
+
+  try {
+    const params = new URLSearchParams({
+      userId,
+      limit: String(limit),
+      offset: String(offset),
+    })
+
+    const res = await fetch(`/api/favorites?${params}`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const responseText = await res.text()
+    console.log('[fetchFavorites] 📥 Response:', {
+      status: res.status,
+      ok: res.ok,
+      bodyPreview: responseText.substring(0, 200),
+    })
+
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`)
+    }
+
+    const json = JSON.parse(responseText)
+    const data = FavoritesResponseSchema.parse(json) // ✅ schema-validated
+
+    if (data.ok) {
+      console.log('[fetchFavorites] ✅ Success:', {
+        count: data.count,
+        hasMore: data.hasMore,
+      })
+      return data
+    }
+
+    console.log('[fetchFavorites] ℹ️  Request failed')
+    return null
+  } catch (err) {
+    console.error('[fetchFavorites] ❌ Failed:', err)
+    return null
+  }
+}

--- a/src/components/mobile/layout.ts
+++ b/src/components/mobile/layout.ts
@@ -42,6 +42,11 @@ import { createStarButton } from './starButton.ts'
 import { createShareButton } from './ui/shareButton.ts'
 import { createSoftResetButton } from './ui/softResetButton.ts'
 import { createStatsButton } from './ui/statsButton.ts'
+import { createFavoritesButton } from './ui/favoritesButton.ts'
+import {
+  createFavoritesModal,
+  setupFavoritesModal,
+} from './ui/favoritesModal.ts'
 
 // --- Constants --------------------------------------------------------------
 const FORCE_RULE_ZERO_OFF = true // avoid strobing
@@ -639,6 +644,38 @@ export async function setupMobileLayout(
     () => updateStats(getCurrentRunData()), // refresh every second
   )
 
+  // Create favorites modal - append to container for proper positioning
+  const {
+    elements: favoritesElements,
+    show: showFavorites,
+    hide: hideFavorites,
+  } = createFavoritesModal({
+    onLoadFavorite: (favorite) => {
+      // Load the favorite into offscreen automata (user will swipe down to see it)
+      const ruleset = hexToC4Ruleset(favorite.ruleset_hex)
+      offScreenRule = {
+        name: favorite.ruleset_name,
+        hex: favorite.ruleset_hex,
+        ruleset: ruleset,
+        seed: favorite.seed,
+      }
+
+      // Prepare offscreen automata with the favorite pattern
+      prepareAutomata(offScreenCA, offScreenRule, lookup, 50)
+      offscreenReady = true
+
+      // Close the modal
+      hideFavorites()
+
+      console.log('[favorites] Loaded favorite pattern:', favorite.ruleset_name)
+    },
+  })
+
+  const cleanupFavoritesModal = setupFavoritesModal(
+    favoritesElements,
+    hideFavorites,
+  )
+
   // Audio update loop (10 Hz / every 100ms)
   let audioUpdateInterval: number | null = null
   const startAudioUpdates = () => {
@@ -785,6 +822,17 @@ export async function setupMobileLayout(
     () => isTransitioning,
   )
 
+  // Create favorites button
+  let favoritesBtn = createFavoritesButton({
+    onOpenFavorites: () => {
+      if (!isTransitioning) {
+        showFavorites()
+        resetControlFade()
+      }
+    },
+    isTransitioning: () => isTransitioning,
+  })
+
   // Wire up died-out callback to pulse reset button
   onDiedOutCallback = () => {
     softResetButton.startPulse()
@@ -792,6 +840,7 @@ export async function setupMobileLayout(
 
   controlContainer.appendChild(softResetButton.button)
   controlContainer.appendChild(starBtn.button)
+  controlContainer.appendChild(favoritesBtn.button)
   controlContainer.appendChild(statsBtn.button)
   controlContainer.appendChild(shareBtn.button)
   wrapper.appendChild(controlContainer)
@@ -966,6 +1015,7 @@ export async function setupMobileLayout(
       shareBtn.cleanup()
       softResetButton.cleanup()
       starBtn.cleanup()
+      favoritesBtn.cleanup()
       statsBtn.cleanup()
 
       shareBtn = createShareButton(
@@ -1021,9 +1071,20 @@ export async function setupMobileLayout(
         () => isTransitioning,
       )
 
+      favoritesBtn = createFavoritesButton({
+        onOpenFavorites: () => {
+          if (!isTransitioning) {
+            showFavorites()
+            resetControlFade()
+          }
+        },
+        isTransitioning: () => isTransitioning,
+      })
+
       controlContainer.innerHTML = ''
       controlContainer.appendChild(softResetButton.button)
       controlContainer.appendChild(starBtn.button)
+      controlContainer.appendChild(favoritesBtn.button)
       controlContainer.appendChild(statsBtn.button)
       controlContainer.appendChild(shareBtn.button)
       resetControlFade()
@@ -1092,6 +1153,7 @@ export async function setupMobileLayout(
     cleanupControlContainer()
     cleanupHeader()
     cleanupStatsOverlay()
+    cleanupFavoritesModal()
     stopAudioUpdates()
     if (audioEngine) {
       ;(audioEngine as AudioEngine).stop()

--- a/src/components/mobile/ui/favoritesButton.ts
+++ b/src/components/mobile/ui/favoritesButton.ts
@@ -1,0 +1,47 @@
+/**
+ * Favorites Button Component
+ *
+ * Button that opens the favorites modal when clicked.
+ */
+
+import { createRoundButton } from '../roundButton'
+
+export interface FavoritesButtonConfig {
+  /** Callback to open favorites modal */
+  onOpenFavorites: () => void
+  /** Callback to check if system is transitioning */
+  isTransitioning: () => boolean
+}
+
+export interface FavoritesButton {
+  button: HTMLButtonElement
+  cleanup: () => void
+}
+
+const favoritesIcon = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+       fill="currentColor" class="w-6 h-6">
+    <path d="M11.645 20.91l-.007-.003-.022-.012a15.247 15.247 0 01-.383-.218 25.18 25.18 0 01-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0112 5.052 5.5 5.5 0 0116.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 01-4.244 3.17 15.247 15.247 0 01-.383.219l-.022.012-.007.004-.003.001a.752.752 0 01-.704 0l-.003-.001z"/>
+  </svg>`
+
+/**
+ * Create a favorites button that opens the favorites modal.
+ */
+export function createFavoritesButton(
+  config: FavoritesButtonConfig,
+): FavoritesButton {
+  const { onOpenFavorites, isTransitioning } = config
+
+  return createRoundButton(
+    {
+      icon: favoritesIcon,
+      title: 'View your favorites',
+      onClick: () => {
+        if (isTransitioning()) return
+        onOpenFavorites()
+      },
+      preventTransition: true,
+    },
+    isTransitioning,
+  )
+}

--- a/src/components/mobile/ui/favoritesModal.ts
+++ b/src/components/mobile/ui/favoritesModal.ts
@@ -1,0 +1,196 @@
+// src/components/mobile/ui/favoritesModal.ts
+
+import type { StarredPattern } from '../../../schema'
+import type { CleanupFunction } from '../../../types'
+import { fetchFavorites } from '../../../api/favorites'
+import { getUserId } from '../../../identity'
+
+export interface FavoritesModalElements {
+  overlay: HTMLDivElement
+  panel: HTMLDivElement
+  closeButton: HTMLButtonElement
+  content: HTMLDivElement
+  grid: HTMLDivElement
+}
+
+export interface FavoritesModalConfig {
+  onLoadFavorite: (favorite: StarredPattern) => void
+}
+
+export function createFavoritesModal(
+  config: FavoritesModalConfig,
+): {
+  elements: FavoritesModalElements
+  show: () => Promise<void>
+  hide: () => void
+} {
+  const overlay = document.createElement('div')
+  overlay.className =
+    'absolute inset-0 z-[1100] bg-black/50 backdrop-blur-sm hidden items-center justify-center p-4 w-full h-full'
+  overlay.style.display = 'none'
+
+  const panel = document.createElement('div')
+  panel.className =
+    'bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-full max-h-[85%] flex flex-col overflow-hidden transform scale-95 transition-transform duration-300'
+
+  const header = document.createElement('div')
+  header.className =
+    'flex-shrink-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-6 py-4 flex items-center justify-between'
+  header.innerHTML = `
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Your Favorites</h2>
+    <button
+      id="close-favorites"
+      class="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+      aria-label="Close"
+    >
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+      </svg>
+    </button>
+  `
+
+  const content = document.createElement('div')
+  content.className = 'flex-1 px-6 py-6 overflow-y-auto min-h-0'
+
+  const grid = document.createElement('div')
+  grid.className = 'grid grid-cols-2 gap-4'
+  content.appendChild(grid)
+
+  const closeButton = header.querySelector(
+    '#close-favorites',
+  ) as HTMLButtonElement
+
+  panel.appendChild(header)
+  panel.appendChild(content)
+  overlay.appendChild(panel)
+  document.body.appendChild(overlay)
+
+  const elements: FavoritesModalElements = {
+    overlay,
+    panel,
+    closeButton,
+    content,
+    grid,
+  }
+
+  const show = async () => {
+    // Show loading state
+    grid.innerHTML = `
+      <div class="col-span-2 text-center py-8">
+        <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 dark:border-gray-100"></div>
+        <p class="mt-2 text-gray-600 dark:text-gray-400">Loading favorites...</p>
+      </div>
+    `
+
+    overlay.style.display = 'flex'
+    document.body.style.overflow = 'hidden'
+    requestAnimationFrame(() => {
+      panel.classList.remove('scale-95')
+      panel.classList.add('scale-100')
+    })
+
+    // Fetch favorites
+    const userId = getUserId()
+    const result = await fetchFavorites(userId, 50, 0)
+
+    if (!result || result.favorites.length === 0) {
+      // Empty state
+      grid.innerHTML = `
+        <div class="col-span-2 text-center py-12">
+          <svg class="w-16 h-16 mx-auto text-gray-400 dark:text-gray-600 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+          </svg>
+          <p class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No favorites yet!</p>
+          <p class="text-sm text-gray-600 dark:text-gray-400">
+            Star interesting patterns to save them here.
+          </p>
+        </div>
+      `
+      return
+    }
+
+    // Render favorite cards
+    grid.innerHTML = ''
+    for (const favorite of result.favorites) {
+      const card = createFavoriteCard(favorite, config)
+      grid.appendChild(card)
+    }
+  }
+
+  const hide = () => {
+    panel.classList.remove('scale-100')
+    panel.classList.add('scale-95')
+    setTimeout(() => {
+      overlay.style.display = 'none'
+      document.body.style.overflow = ''
+    }, 300)
+  }
+
+  return { elements, show, hide }
+}
+
+function createFavoriteCard(
+  favorite: StarredPattern,
+  config: FavoritesModalConfig,
+): HTMLElement {
+  const card = document.createElement('div')
+  card.className =
+    'bg-gray-50 dark:bg-gray-700 rounded-lg p-4 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors'
+
+  // Placeholder preview (gradient)
+  const preview = document.createElement('div')
+  preview.className = 'w-full aspect-square rounded-md mb-3'
+  preview.style.background = 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)'
+
+  const name = document.createElement('div')
+  name.className =
+    'text-sm font-semibold text-gray-900 dark:text-gray-100 mb-1 overflow-hidden text-ellipsis whitespace-nowrap'
+  name.textContent = favorite.ruleset_name || 'Unnamed'
+  name.title = favorite.ruleset_name || 'Unnamed'
+
+  const hex = document.createElement('div')
+  hex.className = 'text-xs text-gray-600 dark:text-gray-400 font-mono'
+  hex.textContent = favorite.ruleset_hex.slice(0, 12) + '...'
+
+  const seedInfo = document.createElement('div')
+  seedInfo.className = 'text-xs text-gray-500 dark:text-gray-500 mt-2'
+  seedInfo.textContent = `Seed: ${favorite.seed} (${favorite.seed_type})`
+
+  card.appendChild(preview)
+  card.appendChild(name)
+  card.appendChild(hex)
+  card.appendChild(seedInfo)
+
+  card.addEventListener('click', () => {
+    config.onLoadFavorite(favorite)
+  })
+
+  return card
+}
+
+export function setupFavoritesModal(
+  elements: FavoritesModalElements,
+  hideCallback: () => void,
+): CleanupFunction {
+  const { overlay, closeButton } = elements
+
+  const closeHandler = () => {
+    hideCallback()
+  }
+
+  const overlayClickHandler = (e: MouseEvent) => {
+    if (e.target === overlay) {
+      hideCallback()
+    }
+  }
+
+  closeButton.addEventListener('click', closeHandler)
+  overlay.addEventListener('click', overlayClickHandler)
+
+  return () => {
+    closeButton.removeEventListener('click', closeHandler)
+    overlay.removeEventListener('click', overlayClickHandler)
+    if (overlay.parentNode) overlay.parentNode.removeChild(overlay)
+    document.body.style.overflow = ''
+  }
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -265,6 +265,13 @@ export const StarredResponse = z.object({
   pattern: StarredPattern.nullable(),
 })
 
+export const FavoritesResponse = z.object({
+  ok: z.boolean(),
+  favorites: z.array(StarredPattern),
+  count: z.number().int().nonnegative(),
+  hasMore: z.boolean(),
+})
+
 // ============================================================================
 // Statistics types
 // ============================================================================
@@ -356,6 +363,7 @@ export type LeaderboardEntry = z.infer<typeof LeaderboardEntry>
 export type LeaderboardResponse = z.infer<typeof LeaderboardResponse>
 export type StarredPattern = z.infer<typeof StarredPattern>
 export type StarredResponse = z.infer<typeof StarredResponse>
+export type FavoritesResponse = z.infer<typeof FavoritesResponse>
 export type OutcomeDistribution = z.infer<typeof OutcomeDistribution>
 export type WolframClassification = z.infer<typeof WolframClassification>
 export type StatisticsData = z.infer<typeof StatisticsData>


### PR DESCRIPTION
## Summary

Implements Issue #185 - Users can now browse and load their previously starred patterns through a dedicated favorites UI.

## What's New

- ✅ Created favorites API endpoint (GET /api/favorites) with pagination support
- ✅ Added frontend API wrapper for fetching favorites
- ✅ Built favorites modal with grid layout for pattern browsing
- ✅ Added favorites button to mobile control panel (heart icon)
- ✅ Integrated favorites modal into mobile layout

## Technical Details

**API Layer:**
- New endpoint `GET /api/favorites` with query parameters:
  - `userId` - Filter by user (default: 'anonymous')
  - `limit` - Number of results (default: 50, max: 100)
  - `offset` - Pagination offset (default: 0)
- Returns `FavoritesResponse` with `favorites` array, `count`, and `hasMore` flag

**UI Layer:**
- Favorites button uses heart icon and follows existing round button pattern
- Modal displays patterns in a 2-column responsive grid
- Empty state with helpful message when no favorites exist
- Loading state with spinner during API fetch
- Click any favorite to load it into offscreen automata (ready for swipe)

**Integration:**
- Full lifecycle integration (creation, cleanup, recreation on swipe)
- Cleanup handlers for modal and button
- Type-safe with Zod schema validation

## Files Changed

- `functions/api/favorites.ts` (new) - Backend API endpoint
- `src/api/favorites.ts` (new) - Frontend API wrapper
- `src/components/mobile/ui/favoritesModal.ts` (new) - Modal component
- `src/components/mobile/ui/favoritesButton.ts` (new) - Button component
- `src/components/mobile/layout.ts` - Integrated favorites button and modal
- `src/schema.ts` - Added FavoritesResponse type

## Testing Checklist

- [x] TypeScript type checking passes
- [ ] Favorites button appears in mobile UI
- [ ] Modal opens and closes correctly
- [ ] Empty state shows when no favorites exist
- [ ] Favorites load from database
- [ ] Clicking a favorite loads it into simulation (offscreen, ready for swipe)
- [ ] No console errors or warnings

## Demo

![image](https://github.com/user-attachments/assets/placeholder)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)